### PR TITLE
Zoom Toolbar hiding

### DIFF
--- a/src/main/java/ecdar/controllers/CanvasShellController.java
+++ b/src/main/java/ecdar/controllers/CanvasShellController.java
@@ -3,6 +3,7 @@ package ecdar.controllers;
 import com.jfoenix.controls.JFXRippler;
 import ecdar.abstractions.Component;
 import ecdar.presentations.CanvasPresentation;
+import ecdar.utility.helpers.ZoomHelper;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.layout.Pane;
@@ -26,6 +27,7 @@ public class CanvasShellController implements Initializable {
     public void initialize(URL location, ResourceBundle resources) {
         canvasPresentation.getController().activeComponentProperty().addListener(((observable, oldValue, newValue) -> {
             toolbar.setVisible(newValue instanceof Component);
+            canvasPresentation.getController().zoomHelper.setActive(newValue instanceof Component);
         }));
     }
     @FXML

--- a/src/main/java/ecdar/controllers/CanvasShellController.java
+++ b/src/main/java/ecdar/controllers/CanvasShellController.java
@@ -1,11 +1,10 @@
 package ecdar.controllers;
 
 import com.jfoenix.controls.JFXRippler;
-import ecdar.Ecdar;
+import ecdar.abstractions.Component;
 import ecdar.presentations.CanvasPresentation;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
-import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 
@@ -24,8 +23,11 @@ public class CanvasShellController implements Initializable {
     public CanvasPresentation canvasPresentation;
 
     @Override
-    public void initialize(URL location, ResourceBundle resources) {}
-
+    public void initialize(URL location, ResourceBundle resources) {
+        canvasPresentation.getController().activeComponentProperty().addListener(((observable, oldValue, newValue) -> {
+            toolbar.setVisible(newValue instanceof Component);
+        }));
+    }
     @FXML
     private void zoomInClicked() {
         canvasPresentation.getController().zoomHelper.zoomIn();

--- a/src/main/java/ecdar/utility/helpers/ZoomHelper.java
+++ b/src/main/java/ecdar/utility/helpers/ZoomHelper.java
@@ -7,6 +7,8 @@ import ecdar.presentations.Grid;
 public class ZoomHelper {
     private CanvasPresentation canvasPresentation;
     private Grid grid;
+    private boolean active = true;
+
     public double minZoomFactor = 0.4;
     public double maxZoomFactor = 4;
 
@@ -26,9 +28,11 @@ public class ZoomHelper {
     }
 
     public void setZoomLevel(Double zoomLevel) {
-        canvasPresentation.setScaleX(zoomLevel);
-        canvasPresentation.setScaleY(zoomLevel);
-        centerComponentAndUpdateGrid(zoomLevel);
+        if (active) {
+            canvasPresentation.setScaleX(zoomLevel);
+            canvasPresentation.setScaleY(zoomLevel);
+            centerComponentAndUpdateGrid(zoomLevel);
+        }
     }
 
     public void setGrid(Grid newGrid) {
@@ -39,66 +43,81 @@ public class ZoomHelper {
      * Zoom in with a delta of 1.2
      */
     public void zoomIn() {
-        double delta = 1.2;
-        double newScale = canvasPresentation.getScaleX() * delta;
+        if (active) {
+            double delta = 1.2;
+            double newScale = canvasPresentation.getScaleX() * delta;
 
-        //Limit for zooming in
-        if(newScale > maxZoomFactor){
-            return;
+            //Limit for zooming in
+            if (newScale > maxZoomFactor) {
+                return;
+            }
+
+            //Scale canvas
+            canvasPresentation.setScaleX(newScale);
+            canvasPresentation.setScaleY(newScale);
+
+            centerComponentAndUpdateGrid(newScale);
         }
-
-        //Scale canvas
-        canvasPresentation.setScaleX(newScale);
-        canvasPresentation.setScaleY(newScale);
-
-        centerComponentAndUpdateGrid(newScale);
     }
 
     /**
      * Zoom out with a delta of 1.2
      */
     public void zoomOut() {
-        double delta = 1.2;
-        double newScale = canvasPresentation.getScaleX() / delta;
+        if (active) {
+            double delta = 1.2;
+            double newScale = canvasPresentation.getScaleX() / delta;
 
-        //Limit for zooming out
-        if(newScale < minZoomFactor){
-            return;
+            //Limit for zooming out
+            if (newScale < minZoomFactor) {
+                return;
+            }
+
+            //Scale canvas
+            canvasPresentation.setScaleX(newScale);
+            canvasPresentation.setScaleY(newScale);
+
+            centerComponentAndUpdateGrid(newScale);
         }
-
-        //Scale canvas
-        canvasPresentation.setScaleX(newScale);
-        canvasPresentation.setScaleY(newScale);
-
-        centerComponentAndUpdateGrid(newScale);
     }
 
     /**
      * Set the zoom multiplier to 1
      */
     public void resetZoom() {
-        canvasPresentation.setScaleX(1);
-        canvasPresentation.setScaleY(1);
+        if (active) {
+            canvasPresentation.setScaleX(1);
+            canvasPresentation.setScaleY(1);
 
-        //Center component
-        centerComponentAndUpdateGrid(1);
+            //Center component
+            centerComponentAndUpdateGrid(1);
+        }
     }
 
     /**
      * Zoom in to fit the component on screen
      */
     public void zoomToFit() {
-        if(EcdarController.getActiveCanvasPresentation().getController().activeComponentPresentation == null) {
-            resetZoom();
-            return;
+        if (active) {
+            if (EcdarController.getActiveCanvasPresentation().getController().activeComponentPresentation == null) {
+                resetZoom();
+                return;
+            }
+            double newScale = Math.min(canvasPresentation.getWidth() / EcdarController.getActiveCanvasPresentation().getController().activeComponentPresentation.getWidth() - 0.1, canvasPresentation.getHeight() / EcdarController.getActiveCanvasPresentation().getController().activeComponentPresentation.getHeight() - 0.2); //0.1 for width and 0.2 for height added for margin
+
+            //Scale canvas
+            canvasPresentation.setScaleX(newScale);
+            canvasPresentation.setScaleY(newScale);
+
+            centerComponentAndUpdateGrid(newScale);
         }
-        double newScale = Math.min(canvasPresentation.getWidth() / EcdarController.getActiveCanvasPresentation().getController().activeComponentPresentation.getWidth() - 0.1, canvasPresentation.getHeight() / EcdarController.getActiveCanvasPresentation().getController().activeComponentPresentation.getHeight() - 0.2); //0.1 for width and 0.2 for height added for margin
+    }
 
-        //Scale canvas
-        canvasPresentation.setScaleX(newScale);
-        canvasPresentation.setScaleY(newScale);
-
-        centerComponentAndUpdateGrid(newScale);
+    /**
+     * Set zoom as active/disabled
+     */
+    public void setActive(boolean activeState) {
+        this.active = activeState;
     }
 
     /**


### PR DESCRIPTION
This update disables the zoom toolbar whenever anything other than a component is being displayed

Current implementation:
![image](https://user-images.githubusercontent.com/42961494/122547434-65365800-d030-11eb-9360-092bbbbdcc33.png)

After update:
![image](https://user-images.githubusercontent.com/42961494/122547332-3ddf8b00-d030-11eb-89a8-c3fd74b9095d.png)