### PR TITLE
File selection for locked backend instances disabled

### DIFF
--- a/src/main/java/ecdar/controllers/BackendInstanceController.java
+++ b/src/main/java/ecdar/controllers/BackendInstanceController.java
@@ -6,7 +6,6 @@ import com.jfoenix.controls.JFXTextField;
 import ecdar.abstractions.BackendInstance;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.Property;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.Cursor;
@@ -62,8 +61,8 @@ public class BackendInstanceController implements Initializable {
             moveBackendInstanceDownRippler.setCursor(Cursor.HAND);
             setHGrow();
 
-            coloredIconAsDisabledBasedOnProperty(removeBackendIcon, defaultBackendRadioButton.selectedProperty());
-            coloredIconAsDisabledBasedOnProperty(pickPathToBackendIcon, backendInstance.getLockedProperty());
+            colorIconAsDisabledBasedOnProperty(removeBackendIcon, defaultBackendRadioButton.selectedProperty());
+            colorIconAsDisabledBasedOnProperty(pickPathToBackendIcon, backendInstance.getLockedProperty());
         });
     }
 
@@ -72,7 +71,7 @@ public class BackendInstanceController implements Initializable {
      * @param icon The icon to change the color of
      * @param property The property to bind to
      */
-    private void coloredIconAsDisabledBasedOnProperty(FontIcon icon, BooleanProperty property) {
+    private void colorIconAsDisabledBasedOnProperty(FontIcon icon, BooleanProperty property) {
         // Disallow the user to pick new backend file location for locked backends
         property.addListener((observable, oldValue, newValue) -> {
             if (newValue) {

--- a/src/main/java/ecdar/controllers/BackendInstanceController.java
+++ b/src/main/java/ecdar/controllers/BackendInstanceController.java
@@ -5,7 +5,8 @@ import com.jfoenix.controls.JFXRippler;
 import com.jfoenix.controls.JFXTextField;
 import ecdar.abstractions.BackendInstance;
 import javafx.application.Platform;
-import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.Property;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.Cursor;
@@ -15,7 +16,6 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
-import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
 import org.kordamp.ikonli.javafx.FontIcon;
 
@@ -26,26 +26,32 @@ import java.util.ResourceBundle;
 public class BackendInstanceController implements Initializable {
     private BackendInstance backendInstance = new BackendInstance();
 
-    public JFXTextField backendName;
+    /* Design elements */
     public Label backendNameIssue;
-    public FontIcon expansionIcon;
     public JFXRippler removeBackendRippler;
     public FontIcon removeBackendIcon;
+    public FontIcon expansionIcon;
     public StackPane content;
     public JFXCheckBox isLocal;
     public HBox addressSection;
-    public JFXTextField address;
     public HBox pathToBackendSection;
     public JFXRippler pickPathToBackend;
-    public JFXTextField pathToBackend;
-    public Label locationIssue;
-    public JFXTextField portRangeStart;
-    public Label portRangeStartIssue;
-    public JFXTextField portRangeEnd;
-    public Label portRangeEndIssue;
-    public Label portRangeIssue;
+    public FontIcon pickPathToBackendIcon;
     public StackPane moveBackendInstanceUpRippler;
     public StackPane moveBackendInstanceDownRippler;
+
+    // Labels for showing potential issues
+    public Label locationIssue;
+    public Label portRangeStartIssue;
+    public Label portRangeEndIssue;
+    public Label portRangeIssue;
+
+    /* Input fields */
+    public JFXTextField backendName;
+    public JFXTextField address;
+    public JFXTextField pathToBackend;
+    public JFXTextField portRangeStart;
+    public JFXTextField portRangeEnd;
     public RadioButton defaultBackendRadioButton;
 
     @Override
@@ -56,21 +62,30 @@ public class BackendInstanceController implements Initializable {
             moveBackendInstanceDownRippler.setCursor(Cursor.HAND);
             setHGrow();
 
-            // Prevent deletion of default backend instance
-            defaultBackendRadioButton.selectedProperty().addListener((observable, oldValue, newValue) -> {
-                if (newValue) {
-                    removeBackendIcon.setFill(Color.GREY);
-                } else {
-                    removeBackendIcon.setFill(Color.BLACK);
-                }
-            });
-
-            if (defaultBackendRadioButton.isSelected()) removeBackendIcon.setFill(Color.GREY);
+            coloredIconAsDisabledBasedOnProperty(removeBackendIcon, defaultBackendRadioButton.selectedProperty());
+            coloredIconAsDisabledBasedOnProperty(pickPathToBackendIcon, backendInstance.getLockedProperty());
         });
     }
 
+    /**
+     * Binds the color of the given icon to the value of BooleanProperty.
+     * @param icon The icon to change the color of
+     * @param property The property to bind to
+     */
+    private void coloredIconAsDisabledBasedOnProperty(FontIcon icon, BooleanProperty property) {
+        // Disallow the user to pick new backend file location for locked backends
+        property.addListener((observable, oldValue, newValue) -> {
+            if (newValue) {
+                icon.setFill(Color.GREY);
+            } else {
+                icon.setFill(Color.BLACK);
+            }
+        });
+        if (property.getValue()) icon.setFill(Color.GREY);
+    }
+
     /***
-     * Sets the BackendInstance object and overrides the current settings shown in the GUI
+     * Sets the backend instance and overrides the current values of the input fields in the GUI.
      * @param instance the new BackendInstance
      */
     public void setBackendInstance(BackendInstance instance) {
@@ -91,6 +106,10 @@ public class BackendInstanceController implements Initializable {
         this.portRangeEnd.setText(String.valueOf(instance.getPortEnd()));
     }
 
+    /**
+     * Updates the values of the backend instance to the values from the input fields.
+     * @return The updated backend instance
+     */
     public BackendInstance updateBackendInstance() {
         backendInstance.setName(backendName.getText());
         backendInstance.setLocal(isLocal.isSelected());

--- a/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
+++ b/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
@@ -14,6 +14,7 @@ import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
 import org.apache.commons.lang3.Range;
 
 import java.io.File;
@@ -44,7 +45,7 @@ public class BackendOptionsDialogController implements Initializable {
 
     /**
      * Reverts any changes made to the backend options by reloading the options specified in the preference file,
-     * or to the default, if no backends are present in the preferences file
+     * or to the default, if no backends are present in the preferences file.
      */
     public void cancelBackendOptionsChanges() {
         initializeBackendInstanceList();
@@ -52,8 +53,7 @@ public class BackendOptionsDialogController implements Initializable {
 
     /**
      * Saves the changes made to the backend options to the preferences file and returns true
-     * if no errors where found in the backend instance definitions, otherwise false
-     *
+     * if no errors where found in the backend instance definitions, otherwise false.
      * @return whether the changes could be saved,
      * meaning that no errors where found in the changes made to the backend options
      */
@@ -88,10 +88,10 @@ public class BackendOptionsDialogController implements Initializable {
     }
 
     /**
-     * Resets the backends to the default backends present in the 'default_backends.json' file
+     * Resets the backends to the default backends present in the 'default_backends.json' file.
      */
     public void resetBackendsToDefault() {
-        updateBackendsInGUI(getDefaultBackends());
+        updateBackendsInGUI(getPackagedBackends());
     }
 
     private void initializeBackendInstanceList() {
@@ -103,7 +103,7 @@ public class BackendOptionsDialogController implements Initializable {
             backends = getBackendsFromJsonArray(
                     JsonParser.parseString(savedBackends).getAsJsonArray());
         } else {
-            backends = getDefaultBackends();
+            backends = getPackagedBackends();
         }
 
         // Style add backend button and handle click event
@@ -117,19 +117,32 @@ public class BackendOptionsDialogController implements Initializable {
         updateBackendsInGUI(backends);
     }
 
+    /**
+     * Clear the backend instance list and add the newly defined backends to it.
+     * @param backends The new list of backends
+     */
     private void updateBackendsInGUI(ArrayList<BackendInstance> backends) {
         backendInstanceList.getChildren().clear();
 
         backends.forEach((bi) -> {
             BackendInstancePresentation newBackendInstancePresentation = new BackendInstancePresentation(bi);
+
+            // Bind input fields that should not be changed for packaged backends to the locked property of the backend instance
             newBackendInstancePresentation.getController().backendName.disableProperty().bind(bi.getLockedProperty());
             newBackendInstancePresentation.getController().pathToBackend.disableProperty().bind(bi.getLockedProperty());
+            newBackendInstancePresentation.getController().pickPathToBackend.disableProperty().bind(bi.getLockedProperty());
+            newBackendInstancePresentation.getController().isLocal.disableProperty().bind(bi.getLockedProperty());
             addBackendInstancePresentationToList(newBackendInstancePresentation);
         });
 
         BackendHelper.updateBackendInstances(backends);
     }
 
+    /**
+     * Instantiate backends defined in the given JsonArray.
+     * @param backends The JsonArray containing the backends
+     * @return An ArrayList of the instantiated backends
+     */
     private ArrayList<BackendInstance> getBackendsFromJsonArray(JsonArray backends) {
         ArrayList<BackendInstance> backendInstances = new ArrayList<>();
         backendInstanceList.getChildren().clear();
@@ -141,7 +154,12 @@ public class BackendOptionsDialogController implements Initializable {
         return backendInstances;
     }
 
-    private ArrayList<BackendInstance> getDefaultBackends() {
+    /**
+     * Checks a set of paths to the packaged engines, j-Ecdar and Reveaal, and instantiates them
+     * if one of the related files exists.
+     * @return Backend instances of the packaged engines
+     */
+    private ArrayList<BackendInstance> getPackagedBackends() {
         ArrayList<BackendInstance> defaultBackends = new ArrayList<>();
 
         // Add Reveaal engine
@@ -153,10 +171,10 @@ public class BackendOptionsDialogController implements Initializable {
         reveaal.setPortEnd(5040);
         reveaal.lockInstance();
 
-        List<File> searchPathForReveaal = List.of(
+        List<File> potentialFilesForReveaal = List.of(
                 new File("lib/Reveaal.exe"), new File("lib/Reveaal")
         );
-        getBackendPathIfFileExists(reveaal, searchPathForReveaal);
+        setBackendPathIfFileExists(reveaal, potentialFilesForReveaal);
         defaultBackends.add(reveaal);
 
         // Add jECDAR engine
@@ -168,19 +186,24 @@ public class BackendOptionsDialogController implements Initializable {
         jEcdar.setPortEnd(5050);
         jEcdar.lockInstance();
 
-        List<File> searchPathForJEcdar = List.of(
+        List<File> potentialFiledForJEcdar = List.of(
                 new File("lib/j-Ecdar.exe"), new File("lib/j-Ecdar.bat")
         );
-        getBackendPathIfFileExists(jEcdar, searchPathForJEcdar);
+        setBackendPathIfFileExists(jEcdar, potentialFiledForJEcdar);
         defaultBackends.add(jEcdar);
 
         return defaultBackends;
     }
 
-    private void getBackendPathIfFileExists(BackendInstance engine, List<File> searchPathForFile) {
+    /**
+     * Sets the path to the backend instance if one of the potential files exists
+     * @param engine         The backend instance of the engine to set the path for
+     * @param potentialFiles List of potential files to use for the engine
+     */
+    private void setBackendPathIfFileExists(BackendInstance engine, List<File> potentialFiles) {
         engine.setBackendLocation("");
 
-        for (var f : searchPathForFile) {
+        for (var f : potentialFiles) {
             if (f.exists()) {
                 engine.setBackendLocation(f.getAbsolutePath());
                 break;
@@ -188,14 +211,20 @@ public class BackendOptionsDialogController implements Initializable {
         }
 
         if (engine.getBackendLocation().equals("")) {
-            throw new RuntimeException("Could not locate file for default engine, checked: " + searchPathForFile.stream().map(File::getPath).collect(Collectors.joining(", ")));
+            throw new RuntimeException("Could not locate file for default engine, checked: " + potentialFiles.stream().map(File::getPath).collect(Collectors.joining(", ")));
         }
     }
 
+    /**
+     * Add the new backend instance presentation to the backend options dialog
+     * @param newBackendInstancePresentation The presentation of the new backend instance
+     */
     private void addBackendInstancePresentationToList(BackendInstancePresentation newBackendInstancePresentation) {
         backendInstanceList.getChildren().add(newBackendInstancePresentation);
         newBackendInstancePresentation.getController().moveBackendInstanceUpRippler.setOnMouseClicked((mouseEvent) -> moveBackendInstance(newBackendInstancePresentation, -1));
         newBackendInstancePresentation.getController().moveBackendInstanceDownRippler.setOnMouseClicked((mouseEvent) -> moveBackendInstance(newBackendInstancePresentation, +1));
+
+        // Set remove backend action to only fire if the backend is not locked
         newBackendInstancePresentation.getController().removeBackendRippler.setOnMouseClicked((mouseEvent) -> {
             if (!newBackendInstancePresentation.getController().defaultBackendRadioButton.isSelected()) {
                 backendInstanceList.getChildren().remove(newBackendInstancePresentation);
@@ -204,20 +233,28 @@ public class BackendOptionsDialogController implements Initializable {
         newBackendInstancePresentation.getController().defaultBackendRadioButton.setToggleGroup(defaultBackendToggleGroup);
     }
 
-    private void moveBackendInstance(BackendInstancePresentation newBackendInstance, int i) {
-        int currentIndex = backendInstanceList.getChildren().indexOf(newBackendInstance);
+    /**
+     * Calculated the location new position of the backend instance, i places further down, in the backend instance list.
+     * The backend instance presentation is removed at added to the new position.
+     * Given a negative value, the instance is moved up. This function uses loop-around, meaning that:
+     * - If the instance is moved down while already at the bottom of the list, it is placed at the top.
+     * - If the instance is moved up while already at the top of the list, it is placed at the bottom.
+     * @param backendInstancePresentation The backend instance presentation to move
+     * @param i                           The number of steps to move the backend instance down
+     */
+    private void moveBackendInstance(BackendInstancePresentation backendInstancePresentation, int i) {
+        int currentIndex = backendInstanceList.getChildren().indexOf(backendInstancePresentation);
         int newIndex = (currentIndex + i) % backendInstanceList.getChildren().size();
         if (newIndex < 0) {
             newIndex = backendInstanceList.getChildren().size() - 1;
         }
 
-        backendInstanceList.getChildren().remove(newBackendInstance);
-        backendInstanceList.getChildren().add(newIndex, newBackendInstance);
+        backendInstanceList.getChildren().remove(backendInstancePresentation);
+        backendInstanceList.getChildren().add(newIndex, backendInstancePresentation);
     }
 
     /**
      * Marks input fields in the backendInstanceList that contains errors and returns whether any errors were found
-     *
      * @return whether any errors were found
      */
     private boolean backendInstanceListIsErrorFree() {

--- a/src/main/resources/ecdar/presentations/BackendInstancePresentation.fxml
+++ b/src/main/resources/ecdar/presentations/BackendInstancePresentation.fxml
@@ -70,7 +70,7 @@
                                     <StackPane minWidth="20" minHeight="20"
                                                onMouseClicked="#openPathToBackendDialog"
                                                StackPane.alignment="TOP_RIGHT">
-                                        <FontIcon iconLiteral="gmi-open-in-new" iconSize="20" fill="black"/>
+                                        <FontIcon fx:id="pickPathToBackendIcon" iconLiteral="gmi-open-in-new" iconSize="20" fill="black"/>
                                     </StackPane>
                                 </JFXRippler>
                             </HBox>


### PR DESCRIPTION
The following changes have been made:
- File selection pop-up on the backend instances in the backend instance options list is now disabled when the backend instance is locked
- Clean-up of some of the files
- Docstrings and comments added to some ambiguous method names