### PR TITLE
Component declaration fixed

### DIFF
--- a/src/main/java/ecdar/controllers/ComponentController.java
+++ b/src/main/java/ecdar/controllers/ComponentController.java
@@ -771,6 +771,7 @@ public class ComponentController extends ModelController implements Initializabl
     private void initializeDeclarations() {
         // Initially style the declarations
         declarationTextArea.setStyleSpans(0, ComponentPresentation.computeHighlighting(getComponent().getDeclarationsText()));
+        declarationTextArea.getStyleClass().add("component-declaration");
 
         final Circle circle = new Circle(0);
         if (getComponent().isDeclarationOpen()) {

--- a/src/main/java/ecdar/presentations/ComponentPresentation.java
+++ b/src/main/java/ecdar/presentations/ComponentPresentation.java
@@ -112,6 +112,7 @@ public class ComponentPresentation extends ModelPresentation implements MouseTra
         // Set a hover effect for the controller.toggleDeclarationButton
         controller.toggleDeclarationButton.setOnMouseEntered(event -> controller.toggleDeclarationButton.setCursor(Cursor.HAND));
         controller.toggleDeclarationButton.setOnMouseExited(event -> controller.toggleDeclarationButton.setCursor(Cursor.DEFAULT));
+        controller.toggleDeclarationButton.setOnMousePressed(controller::toggleDeclaration);
 
     }
 

--- a/src/main/resources/ecdar/main.css
+++ b/src/main/resources/ecdar/main.css
@@ -177,6 +177,10 @@
     -fx-highlight-text-fill: -white;
 }
 
+.component-declaration {
+    -fx-padding: 1.5em 0em 0em 0em;
+}
+
 .menu .label {
     -fx-text-fill: -white;
     -fx-font-family: "Roboto";

--- a/src/main/resources/ecdar/presentations/ComponentPresentation.fxml
+++ b/src/main/resources/ecdar/presentations/ComponentPresentation.fxml
@@ -37,7 +37,7 @@
 
                         <right>
                             <JFXRippler fx:id="toggleDeclarationButton" style="-fx-background-color: pink;" minWidth="25" minHeight="20">
-                                <StackPane onMouseClicked="#toggleDeclaration">
+                                <StackPane>
                                     <FontIcon iconLiteral="gmi-code" iconSize="17" fill="white"/>
                                 </StackPane>
                             </JFXRippler>


### PR DESCRIPTION
For some reason, the onMouseClicked was not being triggered. This replaces the binding in the FXML with a listener in the presentation. A style class has also been added to add an indent at the top of the declaration to avoid the first line number being unreadable