### PR TITLE
Startup exceptions FIXED

### DIFF
--- a/src/main/java/ecdar/Ecdar.java
+++ b/src/main/java/ecdar/Ecdar.java
@@ -124,7 +124,9 @@ public class Ecdar extends Application {
     }
 
     public static void showToast(final String message) {
-        presentation.showSnackbarMessage(message);
+        Platform.runLater(() -> {
+            presentation.showSnackbarMessage(message);
+        });
     }
 
     public static void showHelp() {

--- a/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
+++ b/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
@@ -208,14 +208,7 @@ public class BackendOptionsDialogController implements Initializable {
             }
         }
 
-        if (engine.getBackendLocation().equals("")) {
-            Ecdar.showToast("File for packaged backend: " + engine.getName() +
-                    " could not be loaded. Please make sure that at least one of the following files is placed in the 'lib' directory: " +
-                    potentialFiles.stream().map(File::getPath).collect(Collectors.joining(", ")));
-            return false;
-        }
-
-        return true;
+        return !engine.getBackendLocation().equals("");
     }
 
     /**

--- a/src/main/java/ecdar/controllers/EcdarController.java
+++ b/src/main/java/ecdar/controllers/EcdarController.java
@@ -242,9 +242,12 @@ public class EcdarController implements Initializable {
             }
         });
 
-        // Set default backend instance
-        BackendInstance defaultBackend = BackendHelper.getBackendInstances().stream().filter(BackendInstance::isDefault).findFirst().orElse(BackendHelper.getBackendInstances().get(0));
-        BackendHelper.setDefaultBackendInstance(defaultBackend);
+        if (BackendHelper.getBackendInstances().size() < 1) {
+            Ecdar.showToast("No engines were found. Download j-Ecdar or Reveaal, or add another engine to fix this. No queries can be executed without engines.");
+        } else {
+            BackendInstance defaultBackend = BackendHelper.getBackendInstances().stream().filter(BackendInstance::isDefault).findFirst().orElse(BackendHelper.getBackendInstances().get(0));
+            BackendHelper.setDefaultBackendInstance(defaultBackend);
+        }
     }
 
     private void initializeDialog(JFXDialog dialog, StackPane dialogContainer) {
@@ -660,10 +663,10 @@ public class EcdarController implements Initializable {
         menuBarViewCanvasSplit.setOnAction(event -> {
             final BooleanProperty isSplit = Ecdar.toggleCanvasSplit();
             if (isSplit.get()) {
-                setCanvasModeToSingular();
+                Platform.runLater(this::setCanvasModeToSingular);
                 menuBarViewCanvasSplit.setText("Split canvas");
             } else {
-                setCanvasModeToSplit();
+                Platform.runLater(this::setCanvasModeToSplit);
                 menuBarViewCanvasSplit.setText("Merge canvases");
             }
         });
@@ -907,7 +910,8 @@ public class EcdarController implements Initializable {
         if (model != null) {
             canvasShellPresentation.getController().canvasPresentation.getController().setActiveModel(activeCanvasPresentation.get().getController().getActiveModel());
         } else {
-            canvasShellPresentation.getController().canvasPresentation.getController().setActiveModel(Ecdar.getProject().getComponents().get(0));
+            // If no components where found, the project has not been initialized. The active model will be updated when the project is initialized
+            canvasShellPresentation.getController().canvasPresentation.getController().setActiveModel(Ecdar.getProject().getComponents().stream().findFirst().orElse(null));
         }
 
         canvasPane.getChildren().add(canvasShellPresentation);
@@ -1177,7 +1181,6 @@ public class EcdarController implements Initializable {
 
     /**
      * This method is used to push the contents of the file and query panes when the tab pane is opened
-     *
      */
     private void changeInsetsOfFileAndQueryPanes() {
         if (messageTabPane.getController().isOpen()) {

--- a/src/main/java/ecdar/presentations/EcdarPresentation.java
+++ b/src/main/java/ecdar/presentations/EcdarPresentation.java
@@ -255,6 +255,9 @@ public class EcdarPresentation extends StackPane {
     }
 
     private void initializeToggleQueryPaneFunctionality() {
+        initializeOpenQueryPaneAnimation();
+        initializeCloseQueryPaneAnimation();
+
         // Set the translation of the query pane to be equal to its width
         // Will hide the element, and force it in then the right side of the border pane is enlarged
         controller.queryPane.translateXProperty().bind(controller.queryPane.widthProperty());
@@ -322,6 +325,9 @@ public class EcdarPresentation extends StackPane {
     }
 
     private void initializeToggleFilePaneFunctionality() {
+        initializeOpenFilePaneAnimation();
+        initializeCloseFilePaneAnimation();
+
         // Set the translation of the file pane to be equal to its width
         // Will hide the element, and force it in then the left side of the border pane is enlarged
         controller.filePane.translateXProperty().bind(controller.filePane.widthProperty().multiply(-1));
@@ -459,7 +465,7 @@ public class EcdarPresentation extends StackPane {
 
     public void showSnackbarMessage(final String message) {
         JFXSnackbarLayout content = new JFXSnackbarLayout(message);
-        controller.snackbar.enqueue(new JFXSnackbar.SnackbarEvent(content, new Duration(3000)));
+        controller.snackbar.enqueue(new JFXSnackbar.SnackbarEvent(content, new Duration(5000)));
     }
 
     public void showHelp() {


### PR DESCRIPTION
The following exceptions were encountered after cloning the repository on a system with a fresh installation of Ubuntu 22.04 LTS Desktop without any of the backends installed:
- NullPointer exception caused by attempting to show toast (pop-up message at the bottom of the screen) before the responsible class (EcdarPresentation) had been initialized
- OutOfBounds exception when attempting to fetch default backend, when no backends were found
- NullPointer exception due to animations for file and query panes not being initialized correctly
- NullPointer exception when attempting to set the active model of the canvas before the project was initialized (the list of components was empty)

In addition to the fixes added to handle these exceptions, the following changes were made:
- Toast when no engines have been found added to inform the user that they will need to add one in order to execute queries. 
    - In connection with this, the toasts displayed when either j-Ecdar or Reveaal has not been found have been removed
- Toast duration (how long it appears) changed from 3 to 5 seconds, to make sure that the user has enough time to read the message

Closes #45 