### PR TITLE
Dragging of elements within component

### DIFF
--- a/src/main/java/ecdar/controllers/EdgeController.java
+++ b/src/main/java/ecdar/controllers/EdgeController.java
@@ -669,6 +669,7 @@ public class EdgeController implements Initializable, SelectHelper.ItemSelectabl
 
     @FXML
     public void edgeDragged(final MouseEvent event) {
+        if (event.getTarget() instanceof TagPresentation) return;
         // Check if the edge is selected to ensure that the drag is not targeting a nail
         if (SelectHelper.getSelectedElements().size() == 0 || SelectHelper.getSelectedElements().get(0) == this) {
             DisplayableEdge draggedEdge = edge.get();

--- a/src/main/java/ecdar/controllers/EdgeController.java
+++ b/src/main/java/ecdar/controllers/EdgeController.java
@@ -90,6 +90,7 @@ public class EdgeController implements Initializable, SelectHelper.ItemSelectabl
                         if (nearable instanceof Edge) {
                             if (nearable.equals(getEdge())) {
                                 SelectHelper.addToSelection(EdgeController.this);
+                                edge.get().getNails().forEach(n -> SelectHelper.addToSelection(nailNailPresentationMap.get(n).getController()));
                                 break;
                             }
                         }
@@ -130,7 +131,6 @@ public class EdgeController implements Initializable, SelectHelper.ItemSelectabl
                 // Bind the first link and the arrowhead from the source location to the mouse
                 BindingHelper.bind(link, simpleArrowHead, newEdge.getSourceCircular(), new MouseCircular(newEdge.getSourceCircular()));
             } else if (newEdge.getTargetCircular() != null) {
-
                 edgeRoot.getChildren().add(simpleArrowHead);
 
                 final Circular[] previous = {newEdge.getSourceCircular()};
@@ -655,11 +655,14 @@ public class EdgeController implements Initializable, SelectHelper.ItemSelectabl
             if (event.isShortcutDown()) {
                 if (SelectHelper.getSelectedElements().contains(this)) {
                     SelectHelper.deselect(this);
+                    edge.get().getNails().forEach(n -> SelectHelper.deselect(nailNailPresentationMap.get(n).getController()));
                 } else {
                     SelectHelper.addToSelection(this);
+                    edge.get().getNails().forEach(n -> SelectHelper.addToSelection(nailNailPresentationMap.get(n).getController()));
                 }
             } else {
                 SelectHelper.select(this);
+                edge.get().getNails().forEach(n -> SelectHelper.addToSelection(nailNailPresentationMap.get(n).getController()));
             }
         }
     }

--- a/src/main/java/ecdar/controllers/LocationController.java
+++ b/src/main/java/ecdar/controllers/LocationController.java
@@ -360,6 +360,8 @@ public class LocationController implements Initializable, SelectHelper.ItemSelec
 
     private void initializeMouseControls() {
         final Consumer<MouseEvent> mouseClicked = (event) -> {
+            // Make sure that we are not targeting one of the tags
+            if (!(event.getTarget().equals(notCommittedShape) || event.getTarget().equals(committedShape))) return;
             event.consume();
 
             final Component component = getComponent();

--- a/src/main/java/ecdar/presentations/MultiSyncTagPresentation.java
+++ b/src/main/java/ecdar/presentations/MultiSyncTagPresentation.java
@@ -42,18 +42,13 @@ public class MultiSyncTagPresentation extends TagPresentation {
 
     public MultiSyncTagPresentation(GroupedEdge edge, Runnable updateIOStatusOfSubEdges) {
         this.controller = new EcdarFXMLLoader().loadAndGetController("MultiSyncTagPresentation.fxml", this);
-
         this.edge = edge;
         edge.ioStatus.addListener((observable) -> updateIOStatusOfSubEdges.run());
 
         Platform.runLater(() -> {
             // Added to avoid NullPointer exception for location aware and component in getDragBounds method
-            Nail syncNail = edge.getNails().stream().filter(n -> n.getPropertyType().equals(DisplayableEdge.PropertyType.SYNCHRONIZATION)).findFirst().orElse(null);
-            if (syncNail != null) {
-                setLocationAware(syncNail);
-            }
+            edge.getNails().stream().filter(n -> n.getPropertyType().equals(DisplayableEdge.PropertyType.SYNCHRONIZATION)).findFirst().ifPresent(this::setLocationAware);
             setComponent(EcdarController.getActiveCanvasPresentation().getController().activeComponentPresentation.getController().getComponent());
-
 
             updateTopBorder();
             initializeMouseTransparency();
@@ -84,13 +79,8 @@ public class MultiSyncTagPresentation extends TagPresentation {
 
         edge.getEdges().addListener((ListChangeListener<Edge>) change -> {
             while (change.next()) {
-                if (change.wasRemoved()) {
-                    change.getRemoved().forEach(this::removeSyncTextField);
-                }
-
-                if (change.wasAdded()) {
-                    change.getAddedSubList().forEach(this::addSyncTextField);
-                }
+                if (change.wasRemoved()) change.getRemoved().forEach(this::removeSyncTextField);
+                if (change.wasAdded()) change.getAddedSubList().forEach(this::addSyncTextField);
             }
 
             // Handle height
@@ -202,7 +192,6 @@ public class MultiSyncTagPresentation extends TagPresentation {
                 EcdarController.getActiveCanvasPresentation().getController().activeComponentPresentation.getController().getComponent().getColorIntensity());
 
         controller.frame.setBackground(new Background(new BackgroundFill(color, new CornerRadii(0), Insets.EMPTY)));
-
         controller.frame.setCursor(Cursor.OPEN_HAND);
     }
 
@@ -217,7 +206,6 @@ public class MultiSyncTagPresentation extends TagPresentation {
             event.consume();
 
             SelectHelper.clearSelectedElements();
-
             draggablePreviousX.set(getTranslateX());
             draggablePreviousY.set(getTranslateY());
             dragOffsetX.set(event.getSceneX());
@@ -363,7 +351,6 @@ public class MultiSyncTagPresentation extends TagPresentation {
         double neededLengthForTextField = newWidth;
         for (Node child : controller.syncList.getChildren()) {
             Label currentLabel = ((SyncTextFieldPresentation) child).getController().label;
-
             if (currentLabel.getWidth() > neededLengthForTextField) {
                 neededLengthForTextField = currentLabel.getWidth();
             }

--- a/src/main/java/ecdar/presentations/NailPresentation.java
+++ b/src/main/java/ecdar/presentations/NailPresentation.java
@@ -50,7 +50,6 @@ public class NailPresentation extends Group implements SelectHelper.Selectable, 
                 controller.propertyTag = new TagPresentation();
             }
 
-//            controller.propertyTag = tagPresentation;
             controller.propertyTag.setTranslateX(10);
             controller.propertyTag.setTranslateY(-controller.propertyTag.getHeight());
             this.getChildren().add(controller.propertyTag);

--- a/src/main/java/ecdar/presentations/TagPresentation.java
+++ b/src/main/java/ecdar/presentations/TagPresentation.java
@@ -4,19 +4,22 @@ import ecdar.abstractions.Component;
 import ecdar.controllers.EcdarController;
 import ecdar.utility.UndoRedoStack;
 import ecdar.utility.colors.Color;
+import ecdar.utility.helpers.ItemDragHelper;
 import ecdar.utility.helpers.LocationAware;
 import com.jfoenix.controls.JFXTextField;
+import ecdar.utility.helpers.SelectHelper;
 import javafx.application.Platform;
 import javafx.beans.binding.When;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.property.StringProperty;
+import javafx.beans.property.*;
 import javafx.beans.value.ObservableBooleanValue;
+import javafx.beans.value.ObservableDoubleValue;
 import javafx.geometry.Insets;
-import javafx.geometry.Pos;
 import javafx.scene.Cursor;
 import javafx.scene.control.Label;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
+import javafx.scene.robot.Robot;
 import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;
@@ -35,9 +38,6 @@ public class TagPresentation extends StackPane {
 
     LineTo l2;
     LineTo l3;
-    double previousX;
-    double previousY;
-    boolean wasDragged;
     boolean hadInitialFocus = false;
 
     static double TAG_HEIGHT = 1.6 * GRID_SIZE;
@@ -49,6 +49,20 @@ public class TagPresentation extends StackPane {
         initializeLabel();
         initializeMouseTransparency();
         initializeTextFocusHandler();
+
+        layoutXProperty().addListener((observable, oldValue, newValue) -> {
+            final double trimmedX = getDragBounds().trimX(newValue.doubleValue());
+            if (trimmedX != newValue.doubleValue()) {
+                layoutXProperty().set(trimmedX);
+            }
+        });
+
+        layoutYProperty().addListener((observable, oldValue, newValue) -> {
+            final double trimmedY = getDragBounds().trimY(newValue.doubleValue());
+            if (trimmedY != newValue.doubleValue()) {
+                layoutXProperty().set(trimmedY);
+            }
+        });
     }
 
     void initializeTextFocusHandler() {
@@ -80,8 +94,8 @@ public class TagPresentation extends StackPane {
         final int WIDTH = 5000;
         final double HEIGHT = TAG_HEIGHT;
 
+        final JFXTextField textField = (JFXTextField) lookup("#textField");
         final Path shape = (Path) lookup("#shape");
-
         final MoveTo start = new MoveTo(0, 0);
 
         l2 = new LineTo(WIDTH, 0);
@@ -93,74 +107,9 @@ public class TagPresentation extends StackPane {
 
         shape.setFill(backgroundColor.getColor(backgroundColorIntensity));
         shape.setStroke(backgroundColor.getColor(backgroundColorIntensity.next(4)));
-
-        final JFXTextField textField = (JFXTextField) lookup("#textField");
         shape.setCursor(Cursor.OPEN_HAND);
 
-        shape.setOnMousePressed(event -> {
-            previousX = getTranslateX();
-            previousY = getTranslateY();
-            shape.setCursor(Cursor.CLOSED_HAND);
-        });
-
-        this.setOnMouseDragged(event -> {
-            event.consume();
-
-            final double newX = EcdarController.getActiveCanvasPresentation().mouseTracker.gridXProperty().subtract(getComponent().getBox().getXProperty()).subtract(getLocationAware().xProperty()).doubleValue() - getMinWidth() / 2;
-            setTranslateX(newX);
-
-            final double newY = EcdarController.getActiveCanvasPresentation().mouseTracker.gridYProperty().subtract(getComponent().getBox().getYProperty()).subtract(getLocationAware().yProperty()).doubleValue() - getHeight() / 2;
-            setTranslateY(newY - 2);
-
-            // Tell the mouse release action that we can store an update
-            wasDragged = true;
-        });
-
-        shape.setOnMouseReleased(event -> {
-            if (wasDragged) {
-                // Add to undo redo stack
-                final double currentX = getTranslateX();
-                final double currentY = getTranslateY();
-                final double storePreviousX = previousX;
-                final double storePreviousY = previousY;
-
-                UndoRedoStack.pushAndPerform(
-                        () -> {
-                            setTranslateX(currentX);
-                            setTranslateY(currentY);
-                        },
-                        () -> {
-                            setTranslateX(storePreviousX);
-                            setTranslateY(storePreviousY);
-                        },
-                        String.format("Moved tag from (%f,%f) to (%f,%f)", currentX, currentY, storePreviousX, storePreviousY),
-                        "pin-drop"
-                );
-
-                // Reset the was dragged boolean
-                wasDragged = false;
-            } else if (event.getClickCount() == 2) {
-                textField.setMouseTransparent(false);
-                textField.requestFocus();
-                textField.requestFocus(); // This needs to be done twice because of reasons
-            }
-
-            //Handle the horizontal placement of the tag
-            if (getTranslateX() + locationAware.getValue().getX() + textField.getWidth() * 2 > getComponent().getBox().getX() + getComponent().getBox().getWidth()) {
-                setTranslateX(getComponent().getBox().getX() + getComponent().getBox().getWidth() - locationAware.getValue().getX() - textField.getWidth() * 2);
-            } else if (getTranslateX() + locationAware.getValue().getX() < getComponent().getBox().getX()) {
-                setTranslateX(getComponent().getBox().getX() - locationAware.getValue().getX());
-            }
-
-            //Handle the vertical placement of the tag
-            if (getTranslateY() + locationAware.getValue().getY() + textField.getHeight() * 2 > getComponent().getBox().getY() + getComponent().getBox().getHeight()) {
-                setTranslateY(getComponent().getBox().getY() + getComponent().getBox().getHeight() - locationAware.getValue().getY() - textField.getHeight() * 2);
-            } else if (getTranslateY() + locationAware.getValue().getY() < getComponent().getBox().getY() + GRID_SIZE * 2) {
-                setTranslateY(getComponent().getBox().getY() - locationAware.getValue().getY() + GRID_SIZE * 2);
-            }
-
-            shape.setCursor(Cursor.OPEN_HAND);
-        });
+        initializeDragging(textField, shape);
 
         textField.focusedProperty().addListener((observable, oldValue, newValue) -> {
             if (newValue) {
@@ -173,6 +122,83 @@ public class TagPresentation extends StackPane {
 
         // When enter or escape is pressed release focus
         textField.setOnKeyPressed(EcdarController.getActiveCanvasPresentation().getController().getLeaveTextAreaKeyHandler());
+    }
+
+    private void initializeDragging(JFXTextField textField, Path shape) {
+        final DoubleProperty draggablePreviousX = new SimpleDoubleProperty();
+        final DoubleProperty draggablePreviousY = new SimpleDoubleProperty();
+        final DoubleProperty dragOffsetX = new SimpleDoubleProperty();
+        final DoubleProperty dragOffsetY = new SimpleDoubleProperty();
+        final BooleanProperty wasDragged = new SimpleBooleanProperty();
+
+        shape.addEventHandler(MouseEvent.MOUSE_PRESSED, event -> {
+            event.consume();
+
+            SelectHelper.clearSelectedElements();
+
+            draggablePreviousX.set(getTranslateX());
+            draggablePreviousY.set(getTranslateY());
+            dragOffsetX.set(event.getSceneX());
+            dragOffsetY.set(event.getSceneY());
+
+            // Abandon edge, if drag edge is registered instead of tag drag ToDo: Fix so this is not needed
+            Platform.runLater(() -> {
+                Robot robot = new Robot();
+                robot.keyType(KeyCode.ESCAPE);
+            });
+
+            shape.setCursor(Cursor.CLOSED_HAND);
+        });
+
+        shape.addEventHandler(MouseEvent.MOUSE_DRAGGED, event -> {
+            event.consume();
+
+            final double dragDistanceX = Grid.snap(event.getSceneX() - dragOffsetX.get()) / EcdarController.getActiveCanvasZoomFactor().get();
+            final double dragDistanceY = Grid.snap(event.getSceneY() - dragOffsetY.get()) / EcdarController.getActiveCanvasZoomFactor().get();
+            double draggableNewX = getDragBounds().trimX(draggablePreviousX.get() + dragDistanceX);
+            double draggableNewY = getDragBounds().trimY(draggablePreviousY.get() + dragDistanceY);
+
+            setTranslateX(draggableNewX);
+            setTranslateY(draggableNewY);
+
+            wasDragged.set(true);
+        });
+
+        shape.addEventHandler(MouseEvent.MOUSE_RELEASED, event -> {
+            event.consume();
+            if (wasDragged.get()) {
+                final double draggableCurrentX = getTranslateX();
+                final double draggableCurrentY = getTranslateY();
+                final double previousX = draggablePreviousX.get();
+                final double previousY = draggablePreviousY.get();
+
+
+                if(draggableCurrentX != previousX || draggableCurrentY != previousY) {
+                    UndoRedoStack.pushAndPerform(
+                            () -> {
+                                setTranslateX(draggableCurrentX);
+                                setTranslateY(draggableCurrentY);
+                            },
+                            () -> {
+                                setTranslateX(previousX);
+                                setTranslateY(previousY);
+                            },
+                            String.format("Moved " + this.getClass() + " from (%f,%f) to (%f,%f)", draggableCurrentX, draggableCurrentY, previousX, previousY),
+                            "pin-drop"
+                    );
+                }
+
+                // Reset the was dragged boolean
+                wasDragged.set(false);
+                shape.setCursor(Cursor.OPEN_HAND);
+            }
+
+            if (event.getClickCount() == 2) {
+                textField.setMouseTransparent(false);
+                textField.requestFocus();
+                textField.requestFocus(); // This needs to be done twice because of reasons
+            }
+        });
     }
 
     void initializeLabel() {
@@ -301,6 +327,23 @@ public class TagPresentation extends StackPane {
     public void setDisabledText(boolean bool) {
         final JFXTextField textField = (JFXTextField) lookup("#textField");
         textField.setDisable(true);
+    }
+
+    /**
+     * Get the drag bounds for the tag within the Component
+     * @return drag bounds of the tag within the Component
+     */
+    public ItemDragHelper.DragBounds getDragBounds() {
+        final JFXTextField textField = (JFXTextField) lookup("#textField");
+
+        final ObservableDoubleValue minX = locationAware.get().xProperty().multiply(-1).add(GRID_SIZE);
+        final ObservableDoubleValue maxX = getComponent().getBox().getWidthProperty()
+                .subtract(locationAware.get().xProperty().add(textField.widthProperty()).add(GRID_SIZE));
+        final ObservableDoubleValue minY = locationAware.get().yProperty().multiply(-1).add(GRID_SIZE * 2);
+        final ObservableDoubleValue maxY = getComponent().getBox().getHeightProperty()
+                .subtract(locationAware.get().yProperty().add(textField.heightProperty()).add(GRID_SIZE));
+
+        return new ItemDragHelper.DragBounds(minX, maxX, minY, maxY);
     }
 
     /**

--- a/src/main/java/ecdar/presentations/TagPresentation.java
+++ b/src/main/java/ecdar/presentations/TagPresentation.java
@@ -141,12 +141,6 @@ public class TagPresentation extends StackPane {
             dragOffsetX.set(event.getSceneX());
             dragOffsetY.set(event.getSceneY());
 
-            // Abandon edge, if drag edge is registered instead of tag drag ToDo: Fix so this is not needed
-            Platform.runLater(() -> {
-                Robot robot = new Robot();
-                robot.keyType(KeyCode.ESCAPE);
-            });
-
             shape.setCursor(Cursor.CLOSED_HAND);
         });
 
@@ -196,7 +190,6 @@ public class TagPresentation extends StackPane {
             if (event.getClickCount() == 2) {
                 textField.setMouseTransparent(false);
                 textField.requestFocus();
-                textField.requestFocus(); // This needs to be done twice because of reasons
             }
         });
     }

--- a/src/main/java/ecdar/utility/helpers/ItemDragHelper.java
+++ b/src/main/java/ecdar/utility/helpers/ItemDragHelper.java
@@ -1,6 +1,7 @@
 package ecdar.utility.helpers;
 
 import ecdar.controllers.EcdarController;
+import ecdar.controllers.EdgeController;
 import ecdar.presentations.ComponentOperatorPresentation;
 import ecdar.presentations.ComponentPresentation;
 import ecdar.presentations.Grid;
@@ -138,6 +139,7 @@ public class ItemDragHelper {
 
             for (int i = 0; i < numberOfSelectedItems; i++) {
                 SelectHelper.ItemSelectable item = SelectHelper.getSelectedElements().get(i);
+                if (item instanceof EdgeController) continue;
 
                 if (!item.equals(mouseSubject)) {
                     final double itemNewX = dragBounds.trimX(previousLocations.get(i).getKey() + dragDistanceX);
@@ -198,6 +200,7 @@ public class ItemDragHelper {
 
         for (int i = 0; i < numberOfSelectedItems; i++) {
             SelectHelper.ItemSelectable item = selectedItems.get(i);
+            if (item instanceof EdgeController) continue;
 
             if (!item.equals(mouseSubject)) {
                 // The x and y properties of any ComponentOperatorPresentation is bound and must therefore be set this way instead


### PR DESCRIPTION
After the refactoring of the grid, a bug was introduced where the elements (locations, tags, nails, etc.) jump to coordinates outside of the component when clicked. The dragging of the elements is also off-center from the mouse and does not account for scaling.

Tags jumping off screen on mouse press:
![tag_juming_of_screen_on_press_bug](https://user-images.githubusercontent.com/42961494/177736906-9ee61724-49e0-401e-b346-937d06888ade.GIF)

Elements not sticking to the mouse:
![elements_not_following_mouse_bug](https://user-images.githubusercontent.com/42961494/177737135-d658e609-d60a-4dcb-b2e3-e3abbbe22aa0.GIF)

Edge being dragged weird:
![drag_with_selected_edge_bug](https://user-images.githubusercontent.com/42961494/177737194-9e8150a4-1201-4b30-b571-2fb5e888a768.GIF)

After fix:
![drag_within_component_fixed](https://user-images.githubusercontent.com/42961494/177737332-68dd21bd-95eb-4ce5-8df6-3ec4659ae937.GIF)