### PR TITLE
Simple string validation for component names and queries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation fileTree(dir: 'lib', include: ['*.jar'])
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.8.2'
+    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.8.2'
     implementation 'com.jfoenix:jfoenix:9.0.10'
     implementation group: 'de.codecentric.centerdevice', name: 'javafxsvg', version: '1.3.0'
     implementation group: 'com.github.jiconfont', name: 'jiconfont-javafx', version: '1.0.0'
@@ -77,6 +78,11 @@ dependencies {
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
+}
+
+
+test {
+    useJUnitPlatform { includeEngines 'junit-jupiter' }
 }
 
 protobuf {

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ def protocVersion = protobufVersion
 dependencies {
     implementation fileTree(dir: 'lib', include: ['*.jar'])
 
-    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.8.2'
     implementation 'com.jfoenix:jfoenix:9.0.10'
     implementation group: 'de.codecentric.centerdevice', name: 'javafxsvg', version: '1.3.0'
     implementation group: 'com.github.jiconfont', name: 'jiconfont-javafx', version: '1.0.0'

--- a/src/main/java/ecdar/abstractions/HighLevelModelObject.java
+++ b/src/main/java/ecdar/abstractions/HighLevelModelObject.java
@@ -80,13 +80,12 @@ public abstract class HighLevelModelObject implements Serializable, DropDownMenu
      */
     void setRandomColor() {
         // Color the new component in such a way that we avoid clashing with other components if possible
-        final List<EnabledColor> availableColors = new ArrayList<>();
-        EnabledColor.enabledColors.forEach(availableColors::add);
+        final List<EnabledColor> availableColors = new ArrayList<>(EnabledColor.enabledColors);
         Ecdar.getProject().getComponents().forEach(component -> {
             availableColors.removeIf(enabledColor -> enabledColor.color.equals(component.getColor()));
         });
         if (availableColors.size() == 0) {
-            EnabledColor.enabledColors.forEach(availableColors::add);
+            availableColors.addAll(EnabledColor.enabledColors);
         }
         final int randomIndex = (new Random()).nextInt(availableColors.size());
         final EnabledColor selectedColor = availableColors.get(randomIndex);

--- a/src/main/java/ecdar/abstractions/Query.java
+++ b/src/main/java/ecdar/abstractions/Query.java
@@ -3,6 +3,7 @@ package ecdar.abstractions;
 import ecdar.Ecdar;
 import ecdar.backend.*;
 import ecdar.controllers.EcdarController;
+import ecdar.utility.helpers.StringValidator;
 import ecdar.utility.serialize.Serializable;
 import com.google.gson.JsonObject;
 import javafx.application.Platform;
@@ -229,7 +230,7 @@ public class Query implements Serializable {
     }
 
     public void run() {
-        runQuery.run();
+        if (StringValidator.validateString(query.get(), StringValidator.queryValidation)) runQuery.run();
     }
 
     public void cancel() {

--- a/src/main/java/ecdar/abstractions/Query.java
+++ b/src/main/java/ecdar/abstractions/Query.java
@@ -230,7 +230,7 @@ public class Query implements Serializable {
     }
 
     public void run() {
-        if (StringValidator.validateString(query.get(), StringValidator.queryValidation)) runQuery.run();
+        if (StringValidator.validateQuery(query.get())) runQuery.run();
     }
 
     public void cancel() {

--- a/src/main/java/ecdar/presentations/ModelPresentation.java
+++ b/src/main/java/ecdar/presentations/ModelPresentation.java
@@ -64,7 +64,7 @@ public abstract class ModelPresentation extends HighLevelModelPresentation {
         // Set the text field to the name in the model, and bind the model to the text field
         controller.name.setText(model.getName());
         controller.name.textProperty().addListener((obs, oldName, newName) -> {
-            if (StringValidator.validateString(newName, StringValidator.componentNameValidation)) {
+            if (StringValidator.validateComponentName(newName)) {
                 model.nameProperty().unbind();
                 model.setName(newName);
             } else {

--- a/src/main/java/ecdar/presentations/ModelPresentation.java
+++ b/src/main/java/ecdar/presentations/ModelPresentation.java
@@ -1,5 +1,6 @@
 package ecdar.presentations;
 
+import ecdar.Ecdar;
 import ecdar.abstractions.Box;
 import ecdar.abstractions.HighLevelModelObject;
 import ecdar.controllers.EcdarController;
@@ -68,6 +69,7 @@ public abstract class ModelPresentation extends HighLevelModelPresentation {
                 model.setName(newName);
             } else {
                 controller.name.setText(model.getName());
+                Ecdar.showToast("Component names cannot contain '.'");
             }
         });
 

--- a/src/main/java/ecdar/presentations/ModelPresentation.java
+++ b/src/main/java/ecdar/presentations/ModelPresentation.java
@@ -6,6 +6,7 @@ import ecdar.controllers.EcdarController;
 import ecdar.controllers.ModelController;
 import ecdar.utility.UndoRedoStack;
 import ecdar.utility.colors.Color;
+import ecdar.utility.helpers.StringValidator;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -62,8 +63,12 @@ public abstract class ModelPresentation extends HighLevelModelPresentation {
         // Set the text field to the name in the model, and bind the model to the text field
         controller.name.setText(model.getName());
         controller.name.textProperty().addListener((obs, oldName, newName) -> {
-            model.nameProperty().unbind();
-            model.setName(newName);
+            if (StringValidator.validateString(newName, StringValidator.componentNameValidation)) {
+                model.nameProperty().unbind();
+                model.setName(newName);
+            } else {
+                controller.name.setText(model.getName());
+            }
         });
 
         final Runnable updateColor = () -> {

--- a/src/main/java/ecdar/presentations/QueryPresentation.java
+++ b/src/main/java/ecdar/presentations/QueryPresentation.java
@@ -7,6 +7,7 @@ import ecdar.backend.*;
 import ecdar.controllers.QueryController;
 import ecdar.controllers.EcdarController;
 import ecdar.utility.colors.Color;
+import ecdar.utility.helpers.StringValidator;
 import javafx.application.Platform;
 import javafx.beans.binding.When;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -77,6 +78,14 @@ public class QueryPresentation extends HBox {
                     }
                 });
             }));
+
+            queryTextField.focusedProperty().addListener((observable, oldValue, newValue) -> {
+                if (!newValue && !StringValidator.validateString(queryTextField.getText(), StringValidator.queryValidation)) {
+                    queryTextField.getStyleClass().add("input-violation");
+                } else {
+                    queryTextField.getStyleClass().remove("input-violation");
+                }
+            });
 
             commentTextField.setOnKeyPressed(EcdarController.getActiveCanvasPresentation().getController().getLeaveTextAreaKeyHandler());
         });

--- a/src/main/java/ecdar/presentations/QueryPresentation.java
+++ b/src/main/java/ecdar/presentations/QueryPresentation.java
@@ -80,7 +80,7 @@ public class QueryPresentation extends HBox {
             }));
 
             queryTextField.focusedProperty().addListener((observable, oldValue, newValue) -> {
-                if (!newValue && !StringValidator.validateString(queryTextField.getText(), StringValidator.queryValidation)) {
+                if (!newValue && !StringValidator.validateQuery(queryTextField.getText())) {
                     queryTextField.getStyleClass().add("input-violation");
                 } else {
                     queryTextField.getStyleClass().remove("input-violation");

--- a/src/main/java/ecdar/utility/helpers/StringValidator.java
+++ b/src/main/java/ecdar/utility/helpers/StringValidator.java
@@ -1,32 +1,19 @@
 package ecdar.utility.helpers;
 
 public class StringValidator {
-    public static StringValidationType queryValidation = new StringValidationType() {
-        @Override
-        public boolean validate(String input) {
-            int openingParentheses = 0, closingParentheses = 0;
+    public static boolean validateQuery(String input) {
+        int openingParentheses = 0, closingParentheses = 0;
 
 
-            for (char c : input.toCharArray()) {
-                if (c == '(') openingParentheses++;
-                else if (c == ')') closingParentheses++;
-            }
-
-            return openingParentheses == closingParentheses;
+        for (char c : input.toCharArray()) {
+            if (c == '(') openingParentheses++;
+            else if (c == ')') closingParentheses++;
         }
-    };
-    public static StringValidationType componentNameValidation = new StringValidationType() {
-        @Override
-        public boolean validate(String input) {
-            return !input.contains(".");
-        }
-    };
 
-    public static boolean validateString(String input, StringValidationType validationType) {
-        return validationType.validate(input);
-    };
+        return openingParentheses == closingParentheses;
+    }
 
-    private abstract static class StringValidationType {
-        public abstract boolean validate(String input);
+    public static boolean validateComponentName(String input) {
+        return !input.contains(".");
     }
 }

--- a/src/main/java/ecdar/utility/helpers/StringValidator.java
+++ b/src/main/java/ecdar/utility/helpers/StringValidator.java
@@ -3,8 +3,7 @@ package ecdar.utility.helpers;
 public class StringValidator {
     public static boolean validateQuery(String input) {
         int openingParentheses = 0, closingParentheses = 0;
-
-
+        
         for (char c : input.toCharArray()) {
             if (c == '(') openingParentheses++;
             else if (c == ')') closingParentheses++;

--- a/src/main/java/ecdar/utility/helpers/StringValidator.java
+++ b/src/main/java/ecdar/utility/helpers/StringValidator.java
@@ -1,0 +1,32 @@
+package ecdar.utility.helpers;
+
+public class StringValidator {
+    public static StringValidationType queryValidation = new StringValidationType() {
+        @Override
+        public boolean validate(String input) {
+            int openingParentheses = 0, closingParentheses = 0;
+
+
+            for (char c : input.toCharArray()) {
+                if (c == '(') openingParentheses++;
+                else if (c == ')') closingParentheses++;
+            }
+
+            return openingParentheses == closingParentheses;
+        }
+    };
+    public static StringValidationType componentNameValidation = new StringValidationType() {
+        @Override
+        public boolean validate(String input) {
+            return !input.contains(".");
+        }
+    };
+
+    public static boolean validateString(String input, StringValidationType validationType) {
+        return validationType.validate(input);
+    };
+
+    private abstract static class StringValidationType {
+        public abstract boolean validate(String input);
+    }
+}

--- a/src/test/java/ecdar/abstractions/ComponentTest.java
+++ b/src/test/java/ecdar/abstractions/ComponentTest.java
@@ -1,16 +1,16 @@
 package ecdar.abstractions;
 
 import ecdar.Ecdar;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.List;
 
 public class ComponentTest {
 
-    @Before
-    public void setup() {
+    @BeforeAll
+    static void setup() {
         Ecdar.setUpForTest();
     }
 
@@ -25,7 +25,7 @@ public class ComponentTest {
         final Component clone = original.cloneForVerification();
 
         // Clone has a location with the same id
-        Assert.assertNotNull(clone.findLocation(id1));
+        Assertions.assertNotNull(clone.findLocation(id1));
     }
 
     @Test
@@ -50,17 +50,17 @@ public class ComponentTest {
         final Component clone = original.cloneForVerification();
 
         // The two ids should be different
-        Assert.assertNotEquals(id1, id2);
+        Assertions.assertNotEquals(id1, id2);
 
-        Assert.assertEquals(id1, original.getEdges().get(0).getTargetLocation().getId());
-        Assert.assertEquals(id1, clone.getEdges().get(0).getTargetLocation().getId());
+        Assertions.assertEquals(id1, original.getEdges().get(0).getTargetLocation().getId());
+        Assertions.assertEquals(id1, clone.getEdges().get(0).getTargetLocation().getId());
 
         // Make original change target loc
         edge1.setTargetLocation(loc2);
 
         // Only original should change
-        Assert.assertEquals(id2, original.getEdges().get(0).getTargetLocation().getId());
-        Assert.assertEquals(id1, clone.getEdges().get(0).getTargetLocation().getId());
+        Assertions.assertEquals(id2, original.getEdges().get(0).getTargetLocation().getId());
+        Assertions.assertEquals(id1, clone.getEdges().get(0).getTargetLocation().getId());
     }
 
     @Test
@@ -85,17 +85,17 @@ public class ComponentTest {
         final Component clone = original.cloneForVerification();
 
         // The two ids should be different
-        Assert.assertNotEquals(id1, id2);
+        Assertions.assertNotEquals(id1, id2);
 
-        Assert.assertEquals(id1, original.getEdges().get(0).getTargetLocation().getId());
-        Assert.assertEquals(id1, clone.getEdges().get(0).getTargetLocation().getId());
+        Assertions.assertEquals(id1, original.getEdges().get(0).getTargetLocation().getId());
+        Assertions.assertEquals(id1, clone.getEdges().get(0).getTargetLocation().getId());
 
         // Make clone change target loc
         clone.getEdges().get(0).setTargetLocation(loc2);
 
         // Only original should change
-        Assert.assertEquals(id1, original.getEdges().get(0).getTargetLocation().getId());
-        Assert.assertEquals(id2, clone.getEdges().get(0).getTargetLocation().getId());
+        Assertions.assertEquals(id1, original.getEdges().get(0).getTargetLocation().getId());
+        Assertions.assertEquals(id2, clone.getEdges().get(0).getTargetLocation().getId());
     }
 
     @Test
@@ -138,54 +138,54 @@ public class ComponentTest {
 
         c.updateIOList();
 
-        Assert.assertEquals(3, c.getLocations().size());
-        Assert.assertEquals(3, c.getEdges().size());
+        Assertions.assertEquals(3, c.getLocations().size());
+        Assertions.assertEquals(3, c.getEdges().size());
 
         c.applyAngelicCompletion();
 
-        Assert.assertEquals(3, c.getLocations().size());
+        Assertions.assertEquals(3, c.getLocations().size());
 
-        Assert.assertEquals(8, c.getEdges().size());
+        Assertions.assertEquals(8, c.getEdges().size());
 
         // l1 should have two new input edges without guards
         Edge edge = c.getEdges().get(3);
-        Assert.assertEquals(EdgeStatus.INPUT, edge.getStatus());
-        Assert.assertEquals("a", edge.getSync());
-        Assert.assertEquals("", edge.getGuard());
-        Assert.assertEquals(l1, edge.getSourceLocation());
-        Assert.assertEquals(l1, edge.getTargetLocation());
+        Assertions.assertEquals(EdgeStatus.INPUT, edge.getStatus());
+        Assertions.assertEquals("a", edge.getSync());
+        Assertions.assertEquals("", edge.getGuard());
+        Assertions.assertEquals(l1, edge.getSourceLocation());
+        Assertions.assertEquals(l1, edge.getTargetLocation());
 
         edge = c.getEdges().get(4);
-        Assert.assertEquals(EdgeStatus.INPUT, edge.getStatus());
-        Assert.assertEquals("b", edge.getSync());
-        Assert.assertEquals("", edge.getGuard());
-        Assert.assertEquals(l1, edge.getSourceLocation());
-        Assert.assertEquals(l1, edge.getTargetLocation());
+        Assertions.assertEquals(EdgeStatus.INPUT, edge.getStatus());
+        Assertions.assertEquals("b", edge.getSync());
+        Assertions.assertEquals("", edge.getGuard());
+        Assertions.assertEquals(l1, edge.getSourceLocation());
+        Assertions.assertEquals(l1, edge.getTargetLocation());
 
         // l2 should have one new input edge without guard
         edge = c.getEdges().get(5);
-        Assert.assertEquals(EdgeStatus.INPUT, edge.getStatus());
-        Assert.assertEquals("b", edge.getSync());
-        Assert.assertEquals("", edge.getGuard());
-        Assert.assertEquals(l2, edge.getSourceLocation());
-        Assert.assertEquals(l2, edge.getTargetLocation());
+        Assertions.assertEquals(EdgeStatus.INPUT, edge.getStatus());
+        Assertions.assertEquals("b", edge.getSync());
+        Assertions.assertEquals("", edge.getGuard());
+        Assertions.assertEquals(l2, edge.getSourceLocation());
+        Assertions.assertEquals(l2, edge.getTargetLocation());
 
         // l3 should have two new input edges
         // one without guard
         edge = c.getEdges().get(6);
-        Assert.assertEquals(EdgeStatus.INPUT, edge.getStatus());
-        Assert.assertEquals("a", edge.getSync());
-        Assert.assertEquals("", edge.getGuard());
-        Assert.assertEquals(l3, edge.getSourceLocation());
-        Assert.assertEquals(l3, edge.getTargetLocation());
+        Assertions.assertEquals(EdgeStatus.INPUT, edge.getStatus());
+        Assertions.assertEquals("a", edge.getSync());
+        Assertions.assertEquals("", edge.getGuard());
+        Assertions.assertEquals(l3, edge.getSourceLocation());
+        Assertions.assertEquals(l3, edge.getTargetLocation());
 
         // and one with negated guard
         edge = c.getEdges().get(7);
-        Assert.assertEquals(EdgeStatus.INPUT, edge.getStatus());
-        Assert.assertEquals("b", edge.getSync());
-        Assert.assertEquals("x > 3", edge.getGuard());
-        Assert.assertEquals(l3, edge.getSourceLocation());
-        Assert.assertEquals(l3, edge.getTargetLocation());
+        Assertions.assertEquals(EdgeStatus.INPUT, edge.getStatus());
+        Assertions.assertEquals("b", edge.getSync());
+        Assertions.assertEquals("x > 3", edge.getGuard());
+        Assertions.assertEquals(l3, edge.getSourceLocation());
+        Assertions.assertEquals(l3, edge.getTargetLocation());
     }
 
     @Test
@@ -204,27 +204,27 @@ public class ComponentTest {
 
         c.updateIOList();
 
-        Assert.assertEquals(1, c.getLocations().size());
-        Assert.assertEquals(1, c.getEdges().size());
+        Assertions.assertEquals(1, c.getLocations().size());
+        Assertions.assertEquals(1, c.getEdges().size());
 
         c.applyAngelicCompletion();
 
-        Assert.assertEquals(1, c.getLocations().size());
-        Assert.assertEquals(3, c.getEdges().size());
+        Assertions.assertEquals(1, c.getLocations().size());
+        Assertions.assertEquals(3, c.getEdges().size());
 
         Edge edge = c.getEdges().get(1);
-        Assert.assertEquals(EdgeStatus.INPUT, edge.getStatus());
-        Assert.assertEquals("a", edge.getSync());
-        Assert.assertEquals("x <= 1", edge.getGuard());
-        Assert.assertEquals(l1, edge.getSourceLocation());
-        Assert.assertEquals(l1, edge.getTargetLocation());
+        Assertions.assertEquals(EdgeStatus.INPUT, edge.getStatus());
+        Assertions.assertEquals("a", edge.getSync());
+        Assertions.assertEquals("x <= 1", edge.getGuard());
+        Assertions.assertEquals(l1, edge.getSourceLocation());
+        Assertions.assertEquals(l1, edge.getTargetLocation());
 
         edge = c.getEdges().get(2);
-        Assert.assertEquals(EdgeStatus.INPUT, edge.getStatus());
-        Assert.assertEquals("a", edge.getSync());
-        Assert.assertEquals("x > 3", edge.getGuard());
-        Assert.assertEquals(l1, edge.getSourceLocation());
-        Assert.assertEquals(l1, edge.getTargetLocation());
+        Assertions.assertEquals(EdgeStatus.INPUT, edge.getStatus());
+        Assertions.assertEquals("a", edge.getSync());
+        Assertions.assertEquals("x > 3", edge.getGuard());
+        Assertions.assertEquals(l1, edge.getSourceLocation());
+        Assertions.assertEquals(l1, edge.getTargetLocation());
     }
 
     @Test
@@ -249,20 +249,20 @@ public class ComponentTest {
 
         c.updateIOList();
 
-        Assert.assertEquals(1, c.getLocations().size());
-        Assert.assertEquals(2, c.getEdges().size());
+        Assertions.assertEquals(1, c.getLocations().size());
+        Assertions.assertEquals(2, c.getEdges().size());
 
         c.applyAngelicCompletion();
 
-        Assert.assertEquals(1, c.getLocations().size());
-        Assert.assertEquals(3, c.getEdges().size());
+        Assertions.assertEquals(1, c.getLocations().size());
+        Assertions.assertEquals(3, c.getEdges().size());
 
         final Edge edge = c.getEdges().get(2);
-        Assert.assertEquals(EdgeStatus.INPUT, edge.getStatus());
-        Assert.assertEquals("a", edge.getSync());
-        Assert.assertEquals("x <= 3&&x > 1", edge.getGuard());
-        Assert.assertEquals(l1, edge.getSourceLocation());
-        Assert.assertEquals(l1, edge.getTargetLocation());
+        Assertions.assertEquals(EdgeStatus.INPUT, edge.getStatus());
+        Assertions.assertEquals("a", edge.getSync());
+        Assertions.assertEquals("x <= 3&&x > 1", edge.getGuard());
+        Assertions.assertEquals(l1, edge.getSourceLocation());
+        Assertions.assertEquals(l1, edge.getTargetLocation());
     }
 
     @Test
@@ -281,20 +281,20 @@ public class ComponentTest {
 
         c.updateIOList();
 
-        Assert.assertEquals(1, c.getLocations().size());
-        Assert.assertEquals(1, c.getEdges().size());
+        Assertions.assertEquals(1, c.getLocations().size());
+        Assertions.assertEquals(1, c.getEdges().size());
 
         c.applyAngelicCompletion();
 
-        Assert.assertEquals(1, c.getLocations().size());
-        Assert.assertEquals(2, c.getEdges().size());
+        Assertions.assertEquals(1, c.getLocations().size());
+        Assertions.assertEquals(2, c.getEdges().size());
 
         final Edge edge = c.getEdges().get(1);
-        Assert.assertEquals(EdgeStatus.INPUT, edge.getStatus());
-        Assert.assertEquals("a", edge.getSync());
-        Assert.assertEquals("x - y <= 3 + n % 5", edge.getGuard());
-        Assert.assertEquals(l1, edge.getSourceLocation());
-        Assert.assertEquals(l1, edge.getTargetLocation());
+        Assertions.assertEquals(EdgeStatus.INPUT, edge.getStatus());
+        Assertions.assertEquals("a", edge.getSync());
+        Assertions.assertEquals("x - y <= 3 + n % 5", edge.getGuard());
+        Assertions.assertEquals(l1, edge.getSourceLocation());
+        Assertions.assertEquals(l1, edge.getTargetLocation());
     }
 
     @Test
@@ -304,8 +304,8 @@ public class ComponentTest {
 
         final List<String> clocks = c.getClocks();
 
-        Assert.assertEquals(1, clocks.size());
-        Assert.assertEquals("a", clocks.get(0));
+        Assertions.assertEquals(1, clocks.size());
+        Assertions.assertEquals("a", clocks.get(0));
     }
 
     @Test
@@ -315,9 +315,9 @@ public class ComponentTest {
 
         final List<String> clocks = c.getClocks();
 
-        Assert.assertEquals(2, clocks.size());
-        Assert.assertEquals("a", clocks.get(0));
-        Assert.assertEquals("b", clocks.get(1));
+        Assertions.assertEquals(2, clocks.size());
+        Assertions.assertEquals("a", clocks.get(0));
+        Assertions.assertEquals("b", clocks.get(1));
     }
 
     @Test
@@ -327,7 +327,7 @@ public class ComponentTest {
 
         final List<String> clocks = c.getClocks();
 
-        Assert.assertEquals(0, clocks.size());
+        Assertions.assertEquals(0, clocks.size());
     }
 
     @Test
@@ -337,7 +337,7 @@ public class ComponentTest {
 
         final List<String> clocks = c.getClocks();
 
-        Assert.assertEquals(0, clocks.size());
+        Assertions.assertEquals(0, clocks.size());
     }
 
     @Test
@@ -349,8 +349,8 @@ public class ComponentTest {
 
         final List<String> clocks = c.getClocks();
 
-        Assert.assertEquals(1, clocks.size());
-        Assert.assertEquals("x", clocks.get(0));
+        Assertions.assertEquals(1, clocks.size());
+        Assertions.assertEquals("x", clocks.get(0));
     }
 
     @Test
@@ -360,8 +360,8 @@ public class ComponentTest {
 
         final List<String> vars = c.getLocalVariables();
 
-        Assert.assertEquals(1, vars.size());
-        Assert.assertEquals("sound", vars.get(0));
+        Assertions.assertEquals(1, vars.size());
+        Assertions.assertEquals("sound", vars.get(0));
     }
 
     @Test
@@ -373,8 +373,8 @@ public class ComponentTest {
 
         final List<String> vars = c.getLocalVariables();
 
-        Assert.assertEquals(1, vars.size());
-        Assert.assertEquals("cur", vars.get(0));
+        Assertions.assertEquals(1, vars.size());
+        Assertions.assertEquals("cur", vars.get(0));
     }
 
     @Test
@@ -384,7 +384,7 @@ public class ComponentTest {
 
         final List<String> vars = c.getLocalVariables();
 
-        Assert.assertEquals(1, vars.size());
-        Assert.assertEquals("sound", vars.get(0));
+        Assertions.assertEquals(1, vars.size());
+        Assertions.assertEquals("sound", vars.get(0));
     }
 }

--- a/src/test/java/ecdar/mutation/SimpleComponentSimulationTest.java
+++ b/src/test/java/ecdar/mutation/SimpleComponentSimulationTest.java
@@ -4,8 +4,8 @@ import ecdar.abstractions.Component;
 import ecdar.abstractions.Edge;
 import ecdar.abstractions.EdgeStatus;
 import ecdar.abstractions.Location;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 public class SimpleComponentSimulationTest {
 
@@ -20,23 +20,23 @@ public class SimpleComponentSimulationTest {
 
         final SimpleComponentSimulation s = new SimpleComponentSimulation(c);
 
-        Assert.assertEquals(1, s.getClockValuations().size());
-        Assert.assertTrue(s.getClockValuations().containsKey("x"));
-        Assert.assertTrue(s.getClockValuations().containsValue(0.0));
+        Assertions.assertEquals(1, s.getClockValuations().size());
+        Assertions.assertTrue(s.getClockValuations().containsKey("x"));
+        Assertions.assertTrue(s.getClockValuations().containsValue(0.0));
 
         boolean result = s.delay(1.2);
 
-        Assert.assertEquals(true, result);
-        Assert.assertEquals(1, s.getClockValuations().size());
-        Assert.assertTrue(s.getClockValuations().containsKey("x"));
-        Assert.assertTrue(s.getClockValuations().containsValue(1.2));
+        Assertions.assertEquals(true, result);
+        Assertions.assertEquals(1, s.getClockValuations().size());
+        Assertions.assertTrue(s.getClockValuations().containsKey("x"));
+        Assertions.assertTrue(s.getClockValuations().containsValue(1.2));
 
         result = s.delay(0.3);
 
-        Assert.assertEquals(true, result);
-        Assert.assertEquals(1, s.getClockValuations().size());
-        Assert.assertTrue(s.getClockValuations().containsKey("x"));
-        Assert.assertTrue(s.getClockValuations().containsValue(1.5));
+        Assertions.assertEquals(true, result);
+        Assertions.assertEquals(1, s.getClockValuations().size());
+        Assertions.assertTrue(s.getClockValuations().containsKey("x"));
+        Assertions.assertTrue(s.getClockValuations().containsValue(1.5));
     }
 
     @Test
@@ -57,21 +57,21 @@ public class SimpleComponentSimulationTest {
 
         final SimpleComponentSimulation s = new SimpleComponentSimulation(c);
 
-        Assert.assertEquals(1, s.getClockValuations().size());
-        Assert.assertTrue(s.getClockValuations().containsKey("x"));
-        Assert.assertTrue(s.getClockValuations().containsValue(0.0));
+        Assertions.assertEquals(1, s.getClockValuations().size());
+        Assertions.assertTrue(s.getClockValuations().containsKey("x"));
+        Assertions.assertTrue(s.getClockValuations().containsValue(0.0));
 
         s.delay(1.2);
 
-        Assert.assertEquals(1, s.getClockValuations().size());
-        Assert.assertTrue(s.getClockValuations().containsKey("x"));
-        Assert.assertTrue(s.getClockValuations().containsValue(1.2));
+        Assertions.assertEquals(1, s.getClockValuations().size());
+        Assertions.assertTrue(s.getClockValuations().containsKey("x"));
+        Assertions.assertTrue(s.getClockValuations().containsValue(1.2));
 
         s.runInputAction("a");
 
-        Assert.assertEquals(1, s.getClockValuations().size());
-        Assert.assertTrue(s.getClockValuations().containsKey("x"));
-        Assert.assertTrue(s.getClockValuations().containsValue(0.0));
+        Assertions.assertEquals(1, s.getClockValuations().size());
+        Assertions.assertTrue(s.getClockValuations().containsKey("x"));
+        Assertions.assertTrue(s.getClockValuations().containsValue(0.0));
     }
 
     @Test
@@ -95,12 +95,12 @@ public class SimpleComponentSimulationTest {
 
         final SimpleComponentSimulation s = new SimpleComponentSimulation(c);
 
-        Assert.assertEquals(1, s.getClockValuations().size());
-        Assert.assertEquals("L0", s.getCurrentLocation().getId());
+        Assertions.assertEquals(1, s.getClockValuations().size());
+        Assertions.assertEquals("L0", s.getCurrentLocation().getId());
 
         s.runInputAction("a");
 
-        Assert.assertEquals(1, s.getClockValuations().size());
-        Assert.assertEquals("L1", s.getCurrentLocation().getId());
+        Assertions.assertEquals(1, s.getClockValuations().size());
+        Assertions.assertEquals("L1", s.getCurrentLocation().getId());
     }
 }

--- a/src/test/java/ecdar/mutation/StrategyRuleTest.java
+++ b/src/test/java/ecdar/mutation/StrategyRuleTest.java
@@ -1,9 +1,8 @@
 package ecdar.mutation;
 
 import ecdar.mutation.models.DelayRule;
-import org.junit.Assert;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -13,21 +12,21 @@ public class StrategyRuleTest {
 
     @Test
     public void testIsSatisfied1() {
-        Assert.assertTrue(new DelayRule("true").isSatisfied(new HashMap<>()));
+        Assertions.assertTrue(new DelayRule("true").isSatisfied(new HashMap<>()));
     }
 
     @Test
     public void testIsSatisfied2() {
         final Map<String, Double> values = new HashMap<>();
         values.put("M.e", 20.231);
-        Assert.assertTrue(new DelayRule("(20<M.e)").isSatisfied(values));
+        Assertions.assertTrue(new DelayRule("(20<M.e)").isSatisfied(values));
     }
 
     @Test
     public void testIsSatisfied3() {
         final Map<String, Double> values = new HashMap<>();
         values.put("M.e", 10.231);
-        Assert.assertFalse(new DelayRule("(20<M.e)").isSatisfied(values));
+        Assertions.assertFalse(new DelayRule("(20<M.e)").isSatisfied(values));
     }
 
     @Test
@@ -36,7 +35,7 @@ public class StrategyRuleTest {
         values.put("M.e", 20.231);
         values.put("S.f", 0.0);
         values.put("M.f", 0.0);
-        Assert.assertTrue(new DelayRule("(20<M.e && S.f==M.f && M.f==0)").isSatisfied(values));
+        Assertions.assertTrue(new DelayRule("(20<M.e && S.f==M.f && M.f==0)").isSatisfied(values));
     }
 
     @Test
@@ -45,6 +44,6 @@ public class StrategyRuleTest {
         values.put("M.e", 20.231);
         values.put("S.f", 0.2);
         values.put("M.f", 0.0);
-        Assert.assertFalse(new DelayRule("(20<M.e && S.f==M.f && M.f==0)").isSatisfied(values));
+        Assertions.assertFalse(new DelayRule("(20<M.e && S.f==M.f && M.f==0)").isSatisfied(values));
     }
 }

--- a/src/test/java/ecdar/mutation/operators/ChangeGuardOpClocksOperatorTest.java
+++ b/src/test/java/ecdar/mutation/operators/ChangeGuardOpClocksOperatorTest.java
@@ -6,16 +6,16 @@ import ecdar.abstractions.Edge;
 import ecdar.abstractions.EdgeStatus;
 import ecdar.abstractions.Location;
 import ecdar.mutation.MutationTestingException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.Collection;
 
 public class ChangeGuardOpClocksOperatorTest {
 
-    @Before
-    public void setup() {
+    @BeforeAll
+    static void setup() {
         Ecdar.setUpForTest();
     }
 
@@ -33,11 +33,11 @@ public class ChangeGuardOpClocksOperatorTest {
 
         final Collection<? extends Component> mutants = new ChangeGuardOpClocksOperator().generateMutants(component);
 
-        Assert.assertEquals(1, mutants.size());
-        Assert.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20>x")));
+        Assertions.assertEquals(1, mutants.size());
+        Assertions.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20>x")));
 
         // The original guard should not be present among the mutants
-        Assert.assertTrue(mutants.stream().noneMatch(mutant -> mutant.getDisplayableEdges().stream().anyMatch(e -> e.getGuard().equals("20<=x"))));
+        Assertions.assertTrue(mutants.stream().noneMatch(mutant -> mutant.getDisplayableEdges().stream().anyMatch(e -> e.getGuard().equals("20<=x"))));
     }
 
     @Test
@@ -54,12 +54,12 @@ public class ChangeGuardOpClocksOperatorTest {
 
         final Collection<? extends Component> mutants = new ChangeGuardOpClocksOperator().generateMutants(component);
 
-        Assert.assertEquals(2, mutants.size());
-        Assert.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20<=x")));
-        Assert.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20>x")));
+        Assertions.assertEquals(2, mutants.size());
+        Assertions.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20<=x")));
+        Assertions.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20>x")));
 
         // The original guard should not be present among the mutants
-        Assert.assertTrue(mutants.stream().noneMatch(mutant -> mutant.getDisplayableEdges().stream().anyMatch(e -> e.getGuard().equals("20<x"))));
+        Assertions.assertTrue(mutants.stream().noneMatch(mutant -> mutant.getDisplayableEdges().stream().anyMatch(e -> e.getGuard().equals("20<x"))));
     }
 
     @Test
@@ -75,7 +75,7 @@ public class ChangeGuardOpClocksOperatorTest {
 
         final Collection<? extends Component> mutants = new ChangeGuardOpClocksOperator().generateMutants(component);
 
-        Assert.assertEquals(0, mutants.size());
+        Assertions.assertEquals(0, mutants.size());
     }
     @Test
     public void testComputeGuardNotEqual() throws MutationTestingException {
@@ -91,12 +91,12 @@ public class ChangeGuardOpClocksOperatorTest {
 
         final Collection<? extends Component> mutants = new ChangeGuardOpClocksOperator().generateMutants(component);
 
-        Assert.assertEquals(2, mutants.size());
-        Assert.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20 <= x")));
-        Assert.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20 > x")));
+        Assertions.assertEquals(2, mutants.size());
+        Assertions.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20 <= x")));
+        Assertions.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20 > x")));
 
         // The original guard should not be present among the mutants
-        Assert.assertTrue(mutants.stream().noneMatch(mutant -> mutant.getDisplayableEdges().stream().anyMatch(e -> e.getGuard().equals("20 != x"))));
+        Assertions.assertTrue(mutants.stream().noneMatch(mutant -> mutant.getDisplayableEdges().stream().anyMatch(e -> e.getGuard().equals("20 != x"))));
     }
 
     @Test
@@ -113,12 +113,12 @@ public class ChangeGuardOpClocksOperatorTest {
 
         final Collection<? extends Component> mutants = new ChangeGuardOpClocksOperator().generateMutants(component);
 
-        Assert.assertEquals(3, mutants.size());
-        Assert.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20 > x && y == 2")));
-        Assert.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20 <= x && y > 2")));
+        Assertions.assertEquals(3, mutants.size());
+        Assertions.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20 > x && y == 2")));
+        Assertions.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20 <= x && y > 2")));
 
         // The original guard should not be present among the mutants
-        Assert.assertTrue(mutants.stream().noneMatch(mutant -> mutant.getDisplayableEdges().stream().anyMatch(e -> e.getGuard().equals("20 <= x && y == 2"))));
+        Assertions.assertTrue(mutants.stream().noneMatch(mutant -> mutant.getDisplayableEdges().stream().anyMatch(e -> e.getGuard().equals("20 <= x && y == 2"))));
     }
 
     /**
@@ -139,7 +139,7 @@ public class ChangeGuardOpClocksOperatorTest {
 
         final Collection<? extends Component> mutants = new ChangeGuardOpClocksOperator().generateMutants(component);
 
-        Assert.assertEquals(0, mutants.size());
+        Assertions.assertEquals(0, mutants.size());
     }
 
     /**
@@ -162,7 +162,7 @@ public class ChangeGuardOpClocksOperatorTest {
 
         final Collection<? extends Component> mutants = new ChangeGuardOpClocksOperator().generateMutants(component);
 
-        Assert.assertEquals(1, mutants.size());
-        Assert.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20 > x && a > 0")));
+        Assertions.assertEquals(1, mutants.size());
+        Assertions.assertTrue(mutants.stream().anyMatch(mutant -> mutant.getDisplayableEdges().size() == 1 && mutant.getDisplayableEdges().get(0).getGuard().equals("20 > x && a > 0")));
     }
 }

--- a/src/test/java/ecdar/mutation/operators/ChangeInvariantOperatorTest.java
+++ b/src/test/java/ecdar/mutation/operators/ChangeInvariantOperatorTest.java
@@ -3,9 +3,8 @@ package ecdar.mutation.operators;
 import ecdar.abstractions.Component;
 import ecdar.abstractions.Location;
 import ecdar.mutation.MutationTestingException;
-import ecdar.mutation.operators.ChangeInvariantOperator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.List;
 
@@ -21,8 +20,8 @@ public class ChangeInvariantOperatorTest {
 
         final List<Component> mutants = new ChangeInvariantOperator().generateMutants(c);
 
-        Assert.assertEquals(1, mutants.size());
-        Assert.assertEquals("x < 2 + 1", mutants.get(0).getLocations().get(0).getInvariant());
+        Assertions.assertEquals(1, mutants.size());
+        Assertions.assertEquals("x < 2 + 1", mutants.get(0).getLocations().get(0).getInvariant());
     }
 
     @Test
@@ -35,10 +34,10 @@ public class ChangeInvariantOperatorTest {
 
         final List<Component> mutants = new ChangeInvariantOperator().generateMutants(c);
 
-        Assert.assertEquals(2, mutants.size());
+        Assertions.assertEquals(2, mutants.size());
 
-        Assert.assertEquals(1, mutants.stream().filter(m -> m.getLocations().get(0).getInvariant().equals("x < 2 + 1 && y <= 3")).count());
-        Assert.assertEquals(1, mutants.stream().filter(m -> m.getLocations().get(0).getInvariant().equals("x < 2 && y <= 3 + 1")).count());
+        Assertions.assertEquals(1, mutants.stream().filter(m -> m.getLocations().get(0).getInvariant().equals("x < 2 + 1 && y <= 3")).count());
+        Assertions.assertEquals(1, mutants.stream().filter(m -> m.getLocations().get(0).getInvariant().equals("x < 2 && y <= 3 + 1")).count());
     }
 
     @Test
@@ -55,6 +54,6 @@ public class ChangeInvariantOperatorTest {
 
         final List<Component> mutants = new ChangeInvariantOperator().generateMutants(c);
 
-        Assert.assertEquals(3, mutants.size());
+        Assertions.assertEquals(3, mutants.size());
     }
 }

--- a/src/test/java/ecdar/mutation/operators/ChangeTargetOperatorTest.java
+++ b/src/test/java/ecdar/mutation/operators/ChangeTargetOperatorTest.java
@@ -6,14 +6,14 @@ import ecdar.abstractions.Edge;
 import ecdar.abstractions.EdgeStatus;
 import ecdar.abstractions.Location;
 import ecdar.mutation.operators.ChangeTargetOperator;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 public class ChangeTargetOperatorTest {
 
-    @Before
-    public void setup() {
+    @BeforeAll
+    static void setup() {
         Ecdar.setUpForTest();
     }
 
@@ -49,6 +49,6 @@ public class ChangeTargetOperatorTest {
         component.addEdge(edge);
 
         // 5 edges, 4 locations. Expect 5 * (4 - 1) = 15 mutants
-        Assert.assertEquals(15, new ChangeTargetOperator().generateTestCases(component).size());
+        Assertions.assertEquals(15, new ChangeTargetOperator().generateTestCases(component).size());
     }
 }

--- a/src/test/java/ecdar/mutation/operators/InvertResetOperatorTest.java
+++ b/src/test/java/ecdar/mutation/operators/InvertResetOperatorTest.java
@@ -5,8 +5,8 @@ import ecdar.abstractions.Edge;
 import ecdar.abstractions.EdgeStatus;
 import ecdar.abstractions.Location;
 import ecdar.mutation.MutationTestingException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.Collection;
 
@@ -36,11 +36,11 @@ public class InvertResetOperatorTest {
         final Collection<? extends Component> mutants = new InvertResetOperator().generateMutants(component);
 
         // 2 clocks, 3 edges, we except 2 * 3 = 6 mutants
-        Assert.assertEquals(6, mutants.size());
+        Assertions.assertEquals(6, mutants.size());
 
-        Assert.assertEquals(1, mutants.stream().filter(m -> m.getDisplayableEdges().get(1).getUpdate().isEmpty()).count());
-        Assert.assertEquals(1, mutants.stream().filter(m -> m.getDisplayableEdges().get(1).getUpdate().equals("x = 0, y = 0")).count());
+        Assertions.assertEquals(1, mutants.stream().filter(m -> m.getDisplayableEdges().get(1).getUpdate().isEmpty()).count());
+        Assertions.assertEquals(1, mutants.stream().filter(m -> m.getDisplayableEdges().get(1).getUpdate().equals("x = 0, y = 0")).count());
 
-        Assert.assertEquals(0, mutants.stream().filter(m -> m.getDisplayableEdges().get(2).getUpdate().isEmpty()).count());
+        Assertions.assertEquals(0, mutants.stream().filter(m -> m.getDisplayableEdges().get(2).getUpdate().isEmpty()).count());
     }
 }

--- a/src/test/java/ecdar/mutation/operators/SinkLocationOperatorTest.java
+++ b/src/test/java/ecdar/mutation/operators/SinkLocationOperatorTest.java
@@ -5,8 +5,8 @@ import ecdar.abstractions.Edge;
 import ecdar.abstractions.EdgeStatus;
 import ecdar.abstractions.Location;
 import ecdar.mutation.operators.SinkLocationOperator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 public class SinkLocationOperatorTest {
 
@@ -42,6 +42,6 @@ public class SinkLocationOperatorTest {
         component.addEdge(edge);
 
         // 5 edge. Expect 5 mutants
-        Assert.assertEquals(5, new SinkLocationOperator().generateTestCases(component).size());
+        Assertions.assertEquals(5, new SinkLocationOperator().generateTestCases(component).size());
     }
 }

--- a/src/test/java/ecdar/utility/ExpressionHelperTest.java
+++ b/src/test/java/ecdar/utility/ExpressionHelperTest.java
@@ -1,12 +1,10 @@
 package ecdar.utility;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.*;
 
 public class ExpressionHelperTest {
 
@@ -17,27 +15,27 @@ public class ExpressionHelperTest {
 
         final Map<String, Integer> result = ExpressionHelper.parseUpdate("a=a+1", locals);
 
-        Assert.assertEquals(1, result.size());
-        Assert.assertTrue(result.containsKey("a"));
-        Assert.assertTrue(result.containsValue(3));
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertTrue(result.containsKey("a"));
+        Assertions.assertTrue(result.containsValue(3));
     }
 
     @Test
     public void parseUpdateClock() {
         final Map<String, Integer> result = ExpressionHelper.parseUpdate("x=0", new HashMap<>());
 
-        Assert.assertEquals(1, result.size());
-        Assert.assertTrue(result.containsKey("x"));
-        Assert.assertTrue(result.containsValue(0));
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertTrue(result.containsKey("x"));
+        Assertions.assertTrue(result.containsValue(0));
     }
 
     @Test
     public void parseUpdateClocks() {
         final Map<String, Integer> result = ExpressionHelper.parseUpdate("x=0,\ny=0", new HashMap<>());
 
-        Assert.assertEquals(2, result.size());
-        Assert.assertTrue(result.containsKey("x"));
-        Assert.assertTrue(result.containsKey("y"));
-        Assert.assertTrue(result.values().stream().allMatch(v -> v == 0));
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertTrue(result.containsKey("x"));
+        Assertions.assertTrue(result.containsKey("y"));
+        Assertions.assertTrue(result.values().stream().allMatch(v -> v == 0));
     }
 }

--- a/src/test/java/ecdar/utility/StringValidatorTest.java
+++ b/src/test/java/ecdar/utility/StringValidatorTest.java
@@ -1,0 +1,42 @@
+package ecdar.utility;
+
+import ecdar.utility.helpers.StringValidator;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringValidatorTest {
+    @Test
+    public void validQueryReturnsTrue() {
+        final boolean result = StringValidator.validateString("(A && B)", StringValidator.queryValidation);
+
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void queryWithAdditionalClosingParenthesesReturnsFalse() {
+        final boolean result = StringValidator.validateString("(A && B))", StringValidator.queryValidation);
+
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void queryWithAdditionalOpeningParenthesesReturnsFalse() {
+        final boolean result = StringValidator.validateString("((A && B)", StringValidator.queryValidation);
+
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void validComponentNameReturnsTrue() {
+        final boolean result = StringValidator.validateString("Administrator", StringValidator.componentNameValidation);
+
+        Assert.assertTrue(result);
+    }
+
+    @Test
+    public void componentNameWithPeriodReturnsFalse() {
+        final boolean result = StringValidator.validateString("Administrator.", StringValidator.componentNameValidation);
+
+        Assert.assertFalse(result);
+    }
+}

--- a/src/test/java/ecdar/utility/StringValidatorTest.java
+++ b/src/test/java/ecdar/utility/StringValidatorTest.java
@@ -9,14 +9,14 @@ public class StringValidatorTest {
     public void validQueryReturnsTrue() {
         final boolean result = StringValidator.validateQuery("(A && B)");
 
-        assert result;
+        Assertions.assertTrue(result);
     }
 
     @Test
     public void queryWithAdditionalClosingParenthesesReturnsFalse() {
         final boolean result = StringValidator.validateQuery("(A && B))");
 
-        Assertions.assertTrue(result);
+        Assertions.assertFalse(result);
     }
 
     @Test

--- a/src/test/java/ecdar/utility/StringValidatorTest.java
+++ b/src/test/java/ecdar/utility/StringValidatorTest.java
@@ -7,35 +7,35 @@ import org.junit.Test;
 public class StringValidatorTest {
     @Test
     public void validQueryReturnsTrue() {
-        final boolean result = StringValidator.validateString("(A && B)", StringValidator.queryValidation);
+        final boolean result = StringValidator.validateQuery("(A && B)");
 
         Assert.assertTrue(result);
     }
 
     @Test
     public void queryWithAdditionalClosingParenthesesReturnsFalse() {
-        final boolean result = StringValidator.validateString("(A && B))", StringValidator.queryValidation);
+        final boolean result = StringValidator.validateQuery("(A && B))");
 
         Assert.assertFalse(result);
     }
 
     @Test
     public void queryWithAdditionalOpeningParenthesesReturnsFalse() {
-        final boolean result = StringValidator.validateString("((A && B)", StringValidator.queryValidation);
+        final boolean result = StringValidator.validateQuery("((A && B)");
 
         Assert.assertFalse(result);
     }
 
     @Test
     public void validComponentNameReturnsTrue() {
-        final boolean result = StringValidator.validateString("Administrator", StringValidator.componentNameValidation);
+        final boolean result = StringValidator.validateComponentName("Administrator");
 
         Assert.assertTrue(result);
     }
 
     @Test
     public void componentNameWithPeriodReturnsFalse() {
-        final boolean result = StringValidator.validateString("Administrator.", StringValidator.componentNameValidation);
+        final boolean result = StringValidator.validateComponentName("Administrator.");
 
         Assert.assertFalse(result);
     }

--- a/src/test/java/ecdar/utility/StringValidatorTest.java
+++ b/src/test/java/ecdar/utility/StringValidatorTest.java
@@ -1,42 +1,42 @@
 package ecdar.utility;
 
 import ecdar.utility.helpers.StringValidator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 public class StringValidatorTest {
     @Test
     public void validQueryReturnsTrue() {
         final boolean result = StringValidator.validateQuery("(A && B)");
 
-        Assert.assertTrue(result);
+        assert result;
     }
 
     @Test
     public void queryWithAdditionalClosingParenthesesReturnsFalse() {
         final boolean result = StringValidator.validateQuery("(A && B))");
 
-        Assert.assertFalse(result);
+        Assertions.assertTrue(result);
     }
 
     @Test
     public void queryWithAdditionalOpeningParenthesesReturnsFalse() {
         final boolean result = StringValidator.validateQuery("((A && B)");
 
-        Assert.assertFalse(result);
+        Assertions.assertFalse(result);
     }
 
     @Test
     public void validComponentNameReturnsTrue() {
         final boolean result = StringValidator.validateComponentName("Administrator");
 
-        Assert.assertTrue(result);
+        Assertions.assertTrue(result);
     }
 
     @Test
     public void componentNameWithPeriodReturnsFalse() {
         final boolean result = StringValidator.validateComponentName("Administrator.");
 
-        Assert.assertFalse(result);
+        Assertions.assertFalse(result);
     }
 }


### PR DESCRIPTION
This adds a StringValidatorClass, which is able to validate strings. It can be extended to validate any string, but currently, it is only used for queries and component names in the following ways:
- Query: If there is a mismatch with parentheses, the query text is colored red and the query will not be run
- Component names: If the '.' character is entered, the previous name is inserted, appearing to the user as if the keystroke never happened. Furthermore, a pop-up is shown that notifies the user that this character is not allowed here

Tests have also been added to ensure correctness after future updates

Closes #67 and closes #69 