### PR TITLE
Toggle for running background queries

### DIFF
--- a/src/main/java/ecdar/Ecdar.java
+++ b/src/main/java/ecdar/Ecdar.java
@@ -51,6 +51,7 @@ public class Ecdar extends Application {
     private static Project project;
     private static EcdarPresentation presentation;
     private static BooleanProperty isUICached = new SimpleBooleanProperty();
+    public static BooleanProperty shouldRunBackgroundQueries = new SimpleBooleanProperty(true);
     private static final BooleanProperty isSplit = new SimpleBooleanProperty(true); //Set to true to ensure correct behaviour at first toggle.
     private static final BackendDriver backendDriver = new BackendDriver();
     private Stage debugStage;
@@ -147,8 +148,17 @@ public class Ecdar extends Application {
      */
     public static BooleanProperty toggleUICache() {
         isUICached.set(!isUICached.get());
-
         return isUICached;
+    }
+
+    /**
+     * Toggles whether checks are run in the background.
+     * Running checks in the background increases CPU usage and power consumption.
+     * @return the property specifying whether to run checks in the background
+     */
+    public static BooleanProperty toggleRunBackgroundQueries() {
+        shouldRunBackgroundQueries.set(!shouldRunBackgroundQueries.get());
+        return shouldRunBackgroundQueries;
     }
 
     public static BooleanProperty toggleQueryPane() {

--- a/src/main/java/ecdar/controllers/BackgroundThreadController.java
+++ b/src/main/java/ecdar/controllers/BackgroundThreadController.java
@@ -15,11 +15,10 @@ import java.util.ResourceBundle;
 public class BackgroundThreadController implements Initializable {
 
     public VBox threadContainer;
-    private Map<Thread, BackgroundThreadEntryPresentation> threadToPresentationMap = new HashMap<>();
+    private final Map<Thread, BackgroundThreadEntryPresentation> threadToPresentationMap = new HashMap<>();
 
     @Override
     public void initialize(final URL location, final ResourceBundle resources) {
-
         Debug.backgroundThreads.addListener(new ListChangeListener<Thread>() {
             @Override
             public void onChanged(final Change<? extends Thread> c) {
@@ -42,9 +41,5 @@ public class BackgroundThreadController implements Initializable {
                 }
             }
         });
-
-
     }
-
-
 }

--- a/src/main/java/ecdar/controllers/EcdarController.java
+++ b/src/main/java/ecdar/controllers/EcdarController.java
@@ -5,7 +5,6 @@ import com.google.gson.JsonArray;
 import ecdar.Debug;
 import ecdar.Ecdar;
 import ecdar.abstractions.*;
-import ecdar.backend.BackendException;
 import ecdar.backend.BackendHelper;
 import ecdar.backend.QueryListener;
 import ecdar.code_analysis.CodeAnalysis;
@@ -130,6 +129,7 @@ public class EcdarController implements Initializable {
     public MenuItem menuBarFileExportAsPng;
     public MenuItem menuBarFileExportAsPngNoBorder;
     public MenuItem menuBarOptionsCache;
+    public MenuItem menuBarOptionsBackgroundQueries;
     public MenuItem menuBarOptionsBackendOptions;
     public MenuItem menuBarHelpHelp;
     public MenuItem menuBarHelpAbout;
@@ -210,7 +210,14 @@ public class EcdarController implements Initializable {
         initializeKeybindings();
         initializeStatusBar();
         initializeMenuBar();
-        initializeReachabilityAnalysisThread();
+        initializeBackgroundQueriesThread();
+
+        Ecdar.shouldRunBackgroundQueries.addListener((observable, oldValue, newValue) -> {
+            if (newValue) {
+                // If we want to start reachability analysis in hte background, we must reinitialize the thread, as it will have terminated by now
+                initializeBackgroundQueriesThread();
+            }
+        });
 
         bottomFillerElement.heightProperty().bind(messageTabPane.maxHeightProperty());
         messageTabPane.getController().setRunnableForOpeningAndClosingMessageTabPane(this::changeInsetsOfFileAndQueryPanes);
@@ -272,7 +279,6 @@ public class EcdarController implements Initializable {
         initializeEdgeStatusHandling();
         initializeKeybindings();
         initializeStatusBar();
-        initializeReachabilityAnalysisThread();
     }
 
     /**
@@ -390,9 +396,9 @@ public class EcdarController implements Initializable {
         Platform.runLater(() -> ((JFXRippler) switchEdgeStatusButton.lookup(".jfx-rippler")).setRipplerRecenter(true));
     }
 
-    private void initializeReachabilityAnalysisThread() {
+    private void initializeBackgroundQueriesThread() {
         new Thread(() -> {
-            while (true) {
+            while (Ecdar.shouldRunBackgroundQueries.get()) {
                 // Wait for the reachability (the last time we changed the model) becomes smaller than the current time
                 while (reachabilityTime > System.currentTimeMillis()) {
                     try {
@@ -419,6 +425,9 @@ public class EcdarController implements Initializable {
                     thread.interrupt();
                     Debug.removeThread(thread);
                 }
+
+                // Stop thread if user has toggled background queries off
+                if (!Ecdar.shouldRunBackgroundQueries.get()) return;
 
                 Ecdar.getProject().getQueries().forEach(query -> {
                     if (query.isPeriodic()) query.run();
@@ -589,6 +598,14 @@ public class EcdarController implements Initializable {
             backendOptionsDialog.show(backendOptionsDialogContainer);
             backendOptionsDialog.setMouseTransparent(false);
         });
+
+        menuBarOptionsBackgroundQueries.setOnAction(event -> {
+            final BooleanProperty shouldRunBackgroundQueries = Ecdar.toggleRunBackgroundQueries();
+            Ecdar.preferences.putBoolean("run_background_queries", shouldRunBackgroundQueries.get());
+        });
+
+        Ecdar.shouldRunBackgroundQueries.setValue(Ecdar.preferences.getBoolean("run_background_queries", true));
+        menuBarOptionsBackgroundQueries.getGraphic().opacityProperty().bind(new When(Ecdar.shouldRunBackgroundQueries).then(1).otherwise(0));
     }
 
     private void initializeEditMenu() {

--- a/src/main/resources/ecdar/presentations/EcdarPresentation.fxml
+++ b/src/main/resources/ecdar/presentations/EcdarPresentation.fxml
@@ -254,6 +254,12 @@
                             </graphic>
                         </MenuItem>
 
+                        <MenuItem fx:id="menuBarOptionsBackgroundQueries" text="Periodic query execution">
+                            <graphic>
+                                <FontIcon iconLiteral="gmi-check" fill="black" styleClass="icon-size-medium"/>
+                            </graphic>
+                        </MenuItem>
+
                         <SeparatorMenuItem/>
 
                         <MenuItem fx:id="menuBarOptionsBackendOptions" text="Backend options">


### PR DESCRIPTION
This adds a toggle for disabling background queries to allow the user to turn off background threads for periodic queries and reachability analysis