### PR TITLE
Backend refactor

### DIFF
--- a/src/main/java/ecdar/Ecdar.java
+++ b/src/main/java/ecdar/Ecdar.java
@@ -315,6 +315,8 @@ public class Ecdar extends Application {
         });
 
         BackendHelper.addBackendInstanceListener(() -> {
+            // When the backend instances change, re-instantiate the backendDriver
+            // to prevent dangling connections and queries
             try {
                 backendDriver.closeAllBackendConnections();
             } catch (IOException e) {

--- a/src/main/java/ecdar/Ecdar.java
+++ b/src/main/java/ecdar/Ecdar.java
@@ -53,7 +53,7 @@ public class Ecdar extends Application {
     private static BooleanProperty isUICached = new SimpleBooleanProperty();
     public static BooleanProperty shouldRunBackgroundQueries = new SimpleBooleanProperty(true);
     private static final BooleanProperty isSplit = new SimpleBooleanProperty(true); //Set to true to ensure correct behaviour at first toggle.
-    private static final BackendDriver backendDriver = new BackendDriver();
+    private static BackendDriver backendDriver = new BackendDriver();
     private Stage debugStage;
 
     /**
@@ -312,6 +312,16 @@ public class Ecdar extends Application {
 
             Platform.exit();
             System.exit(0);
+        });
+
+        BackendHelper.addBackendInstanceListener(() -> {
+            try {
+                backendDriver.closeAllBackendConnections();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            backendDriver = new BackendDriver();
         });
     }
 

--- a/src/main/java/ecdar/backend/BackendDriver.java
+++ b/src/main/java/ecdar/backend/BackendDriver.java
@@ -20,13 +20,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 public class BackendDriver {
+    private final BlockingQueue<ExecutableQuery> queryQueue = new ArrayBlockingQueue<>(200);
     private final Map<BackendInstance, BlockingQueue<BackendConnection>> openBackendConnections = new HashMap<>();
     private final int deadlineForResponses = 20000;
     private final int rerunQueryDelay = 200;
     private final int numberOfRetriesPerQuery = 5;
-    BlockingQueue<ExecutableQuery> queryQueue = new ArrayBlockingQueue<>(200);
 
     public BackendDriver() {
+        // ToDo NIELS: Consider multiple consumer threads using 'for(int i = 0; i < x; i++) {}'
         QueryConsumer consumer = new QueryConsumer(queryQueue);
         Thread consumerThread = new Thread(consumer);
         consumerThread.start();
@@ -53,7 +54,7 @@ public class BackendDriver {
     /**
      * ToDo NIELS: Reimplement this with query queue when backends support this feature
      * Asynchronous method for fetching inputs and outputs for the given refinement query and adding these to the
-     * ignored inputs and outputs pane for the given query
+     * ignored inputs and outputs pane for the given query.
      *
      * @param query           the ignored input output query containing the query and related GUI elements
      * @param backendInstance the backend that should be used to execute the query
@@ -121,7 +122,7 @@ public class BackendDriver {
 
     /**
      * Executes the specified query as a gRPC request using the specified backend connection.
-     * componentsBuilder is used to update the components of the engine
+     * componentsBuilder is used to update the components of the engine.
      *
      * @param executableQuery   executable query to be executed by the backend
      * @param backendConnection connection to the backend
@@ -143,7 +144,7 @@ public class BackendDriver {
      * Executes the specified query as a gRPC request using the specified backend connection.
      * componentsBuilder is used to update the components of the engine and on completion of this transaction,
      * the query is sent and its response is consumed by responseConsumer. Any error encountered is handled by
-     * the errorConsumer
+     * the errorConsumer.
      *
      * @param query                       query to be executed by the backend
      * @param backendConnection           connection to the backend
@@ -212,7 +213,7 @@ public class BackendDriver {
 
     /**
      * Filters the list of open {@link BackendConnection}s to the specified {@link BackendInstance} and returns the
-     * first match or attempts to start a new connection if none is found
+     * first match or attempts to start a new connection if none is found.
      *
      * @param backend backend instance to get a connection to (e.g. Reveaal, j-Ecdar, custom_engine)
      * @return a BackendConnection object linked to the backend, either from the open backend connection list
@@ -326,7 +327,7 @@ public class BackendDriver {
     }
 
     private void handleQueryBackendError(Throwable t, ExecutableQuery executableQuery) {
-        // If the query has been cancelled, ignore the result
+        // If the query has been cancelled, ignore the error
         if (executableQuery.queryListener.getQuery().getQueryState() == QueryState.UNKNOWN) return;
 
         // Each error starts with a capitalized description of the error equal to the gRPC error type encountered

--- a/src/main/java/ecdar/backend/BackendException.java
+++ b/src/main/java/ecdar/backend/BackendException.java
@@ -9,13 +9,23 @@ public class BackendException extends Exception {
         super(message, cause);
     }
 
-    public static class BadBackendQueryException extends BackendException {
-        public BadBackendQueryException(final String s) {
-            super(s);
+    public static class NoAvailableBackendConnectionException extends BackendException {
+        public NoAvailableBackendConnectionException(final String message) {
+            super(message);
         }
 
-        public BadBackendQueryException(final String s, final Exception cause) {
-            super(s, cause);
+        public NoAvailableBackendConnectionException(final String message, final Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static class BadBackendQueryException extends BackendException {
+        public BadBackendQueryException(final String message) {
+            super(message);
+        }
+
+        public BadBackendQueryException(final String message, final Exception cause) {
+            super(message, cause);
         }
     }
 
@@ -24,8 +34,8 @@ public class BackendException extends Exception {
             super(s);
         }
 
-        public MissingFileQueryException(final String s, final Exception cause) {
-            super(s, cause);
+        public MissingFileQueryException(final String message, final Exception cause) {
+            super(message, cause);
         }
     }
 
@@ -40,13 +50,13 @@ public class BackendException extends Exception {
         }
     }
 
-    public class QueryUncertainException extends BackendException {
+    public static class QueryUncertainException extends BackendException {
         public QueryUncertainException(final String s) {
             super(s);
         }
 
-        public QueryUncertainException(final String s, final Exception cause) {
-            super(s, cause);
+        public QueryUncertainException(final String message, final Exception cause) {
+            super(message, cause);
         }
     }
 }

--- a/src/main/java/ecdar/backend/IgnoredInputOutputQuery.java
+++ b/src/main/java/ecdar/backend/IgnoredInputOutputQuery.java
@@ -14,6 +14,7 @@ public class IgnoredInputOutputQuery {
     private final VBox ignoredInputsVBox;
     private final HashMap<String, Boolean> ignoredOutputs;
     private final VBox ignoredOutputsVBox;
+    public int tries = 0;
 
     public IgnoredInputOutputQuery(Query query, QueryPresentation queryPresentation, HashMap<String, Boolean> ignoredInputs, VBox ignoredInputsVBox, HashMap<String, Boolean> ignoredOutputs, VBox ignoredOutputsVBox) {
         this.query = query;

--- a/src/main/java/ecdar/controllers/QueryController.java
+++ b/src/main/java/ecdar/controllers/QueryController.java
@@ -51,13 +51,30 @@ public class QueryController implements Initializable {
             }
         }));
 
-        backendsDropdown.setValue(query.getBackend());
+        if (BackendHelper.getBackendInstances().contains(query.getBackend())) {
+            backendsDropdown.setValue(query.getBackend());
+        } else {
+            backendsDropdown.setValue(BackendHelper.getDefaultBackendInstance());
+        }
+
         backendsDropdown.valueProperty().addListener((observable, oldValue, newValue) -> {
             if (newValue != null) {
                 query.setBackend(newValue);
             } else {
                 backendsDropdown.setValue(BackendHelper.getDefaultBackendInstance());
             }
+        });
+
+        BackendHelper.addBackendInstanceListener(() -> {
+            Platform.runLater(() -> {
+                // The value must be set before the items (https://stackoverflow.com/a/29483445)
+                if (BackendHelper.getBackendInstances().contains(query.getBackend())) {
+                    backendsDropdown.setValue(query.getBackend());
+                } else {
+                    backendsDropdown.setValue(BackendHelper.getDefaultBackendInstance());
+                }
+                backendsDropdown.setItems(BackendHelper.getBackendInstances());
+            });
         });
     }
 

--- a/src/main/java/ecdar/presentations/QueryPresentation.java
+++ b/src/main/java/ecdar/presentations/QueryPresentation.java
@@ -20,9 +20,11 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.layout.*;
 import javafx.scene.text.TextAlignment;
 import org.kordamp.ikonli.javafx.FontIcon;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+
 import static javafx.scene.paint.Color.*;
 
 public class QueryPresentation extends HBox {
@@ -49,12 +51,9 @@ public class QueryPresentation extends HBox {
 
     private void initializeBackendsDropdown() {
         controller.backendsDropdown.setItems(BackendHelper.getBackendInstances());
-        BackendHelper.addBackendInstanceListener(() -> controller.backendsDropdown.setItems(BackendHelper.getBackendInstances()));
-
         backendDropdownTooltip = new Tooltip();
         backendDropdownTooltip.setText("Current backend used for the query");
         JFXTooltip.install(controller.backendsDropdown, backendDropdownTooltip);
-
         controller.backendsDropdown.setValue(BackendHelper.getDefaultBackendInstance());
     }
 


### PR DESCRIPTION
Refactoring and performance improvements of the communication with the engines. This is mainly achieved through the use of `BlockingQueue`'s for queries and connections, preventing multiple queries from being executed on the same connection at the same time

The following issues have been resolved:
- gRPC channels being over-requested, resulting in exceptions when executing queries in batches
- gRPC channels not being shut down properly, resulting in dangling channels
- Query backend dropdown not having a value or being set to a backend that had been removed
- Duplicate code blocks for gRPC communication (mainly refactored in preparation for simulation queries)

Additionally, multiple consumer threads could be started in the ´BackendDriver´ to execute queries multithreaded (this has been tested). However, as the performance is quite good with just a single thread, this has not been implemented yet.