### PR TITLE
Declaration placement FIX

### DIFF
--- a/src/main/java/ecdar/controllers/CanvasController.java
+++ b/src/main/java/ecdar/controllers/CanvasController.java
@@ -164,7 +164,7 @@ public class CanvasController implements Initializable {
      */
     private void onActiveModelChanged(final HighLevelModelObject oldObject, final HighLevelModelObject newObject) {
         // If old object is a component or system, add to map in order to remember coordinate
-        if (oldObject != null && (oldObject instanceof Component || oldObject instanceof EcdarSystem)) {
+        if ((oldObject instanceof Component || oldObject instanceof EcdarSystem)) {
             ModelObjectTranslateMap.put(oldObject, new Pair<>(modelPane.getTranslateX(), modelPane.getTranslateY()));
         }
 
@@ -200,10 +200,15 @@ public class CanvasController implements Initializable {
         }
 
         boolean shouldZoomBeActive = newObject instanceof Component || newObject instanceof EcdarSystem;
-        toolbar.setVisible(shouldZoomBeActive);
-        zoomHelper.setActive(shouldZoomBeActive);
+        setZoomAvailable(shouldZoomBeActive);
 
         root.requestFocus();
+    }
+
+    private void setZoomAvailable(boolean shouldZoomBeActive) {
+        toolbar.setVisible(shouldZoomBeActive);
+        toolbar.getParent().setMouseTransparent(!shouldZoomBeActive); // Avoid mouse being intercepted on declaration
+        zoomHelper.setActive(shouldZoomBeActive);
     }
 
     /**

--- a/src/main/java/ecdar/controllers/DeclarationsController.java
+++ b/src/main/java/ecdar/controllers/DeclarationsController.java
@@ -6,6 +6,7 @@ import ecdar.presentations.ComponentPresentation;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.fxml.Initializable;
+import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.StackPane;
 import org.fxmisc.richtext.LineNumberFactory;
 import org.fxmisc.richtext.StyleClassedTextArea;
@@ -19,8 +20,8 @@ import java.util.ResourceBundle;
 public class DeclarationsController implements Initializable {
     public StyleClassedTextArea textArea;
     public StackPane root;
+    public BorderPane frame;
 
-    private double offSet;
     private final ObjectProperty<Declarations> declarations;
 
     public DeclarationsController() {
@@ -46,11 +47,7 @@ public class DeclarationsController implements Initializable {
         root.maxWidthProperty().bind(Ecdar.getPresentation().getController().canvasPane.maxWidthProperty());
         root.minHeightProperty().bind(Ecdar.getPresentation().getController().canvasPane.minHeightProperty());
         root.maxHeightProperty().bind(Ecdar.getPresentation().getController().canvasPane.maxHeightProperty());
-
-        updateOffset(EcdarController.getActiveCanvasPresentation().getController().getInsetShouldShow().get());
-        EcdarController.getActiveCanvasPresentation().getController().getInsetShouldShow().addListener((observable, oldValue, newValue) -> {
-            updateOffset(newValue);
-        });
+        textArea.setTranslateY(20);
     }
 
     /**
@@ -76,18 +73,5 @@ public class DeclarationsController implements Initializable {
      */
     public void updateHighlighting() {
         textArea.setStyleSpans(0, ComponentPresentation.computeHighlighting(declarations.get().getDeclarationsText()));
-    }
-
-    /**
-     * Updates if height of the view should have an offset at the bottom.
-     * Whether the view should have an offset is based on the configuration of the error view.
-     * @param shouldHave true iff views should have an offset
-     */
-    private void updateOffset(final boolean shouldHave) {
-        if (shouldHave) {
-            offSet = 20;
-        } else {
-            offSet = 0;
-        }
     }
 }

--- a/src/main/java/ecdar/controllers/FileController.java
+++ b/src/main/java/ecdar/controllers/FileController.java
@@ -14,7 +14,7 @@ import java.util.ResourceBundle;
 public class FileController implements Initializable {
     public JFXRippler moreInformation;
     public ImageView fileImage;
-    public StackPane filePane;
+    public StackPane fileImageStackPane;
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {

--- a/src/main/java/ecdar/controllers/ProjectPaneController.java
+++ b/src/main/java/ecdar/controllers/ProjectPaneController.java
@@ -26,6 +26,7 @@ import javafx.scene.layout.VBox;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.ResourceBundle;
 
@@ -52,6 +53,7 @@ public class ProjectPaneController implements Initializable {
         globalDclPresentation.setOnMousePressed(event -> {
             event.consume();
             EcdarController.setActiveModelForActiveCanvas(Ecdar.getProject().getGlobalDeclarations());
+            updateColorsOnFilePresentations();
         });
         filesList.getChildren().add(globalDclPresentation);
 
@@ -97,9 +99,8 @@ public class ProjectPaneController implements Initializable {
     }
 
     private void sortPresentations() {
-        final ArrayList<HighLevelModelObject> sortedComponentList = new ArrayList<>();
-        modelPresentationMap.keySet().forEach(sortedComponentList::add);
-        sortedComponentList.sort((o1, o2) -> o1.getName().compareTo(o2.getName()));
+        final ArrayList<HighLevelModelObject> sortedComponentList = new ArrayList<>(modelPresentationMap.keySet());
+        sortedComponentList.sort(Comparator.comparing(HighLevelModelObject::getName));
         sortedComponentList.forEach(component -> modelPresentationMap.get(component).toFront());
     }
 
@@ -180,8 +181,6 @@ public class ProjectPaneController implements Initializable {
                 moreInformationDropDown.hide();
             });
         }
-
-
 
         if (model instanceof MutationTestPlan) {
             moreInformationDropDown.addListElement("Name");

--- a/src/main/java/ecdar/presentations/FilePresentation.java
+++ b/src/main/java/ecdar/presentations/FilePresentation.java
@@ -157,7 +157,7 @@ public class FilePresentation extends AnchorPane {
         } else {
             controller.fileImage.setImage(new Image(Ecdar.class.getResource("description_frame.png").toExternalForm()));
         }
-        EcdarPresentation.fitSizeWhenAvailable(controller.fileImage, controller.filePane);
+        EcdarPresentation.fitSizeWhenAvailable(controller.fileImage, controller.fileImageStackPane);
     }
 
     public HighLevelModelObject getModel() {

--- a/src/main/resources/ecdar/presentations/DeclarationPresentation.fxml
+++ b/src/main/resources/ecdar/presentations/DeclarationPresentation.fxml
@@ -6,7 +6,6 @@
          xmlns="http://javafx.com/javafx/8.0.76-ea"
          type="StackPane"
          fx:id="root"
-         style="-fx-background-color: #ff0000;"
          fx:controller="ecdar.controllers.DeclarationsController">
     <BorderPane fx:id="frame" pickOnBounds="false" >
         <center>

--- a/src/main/resources/ecdar/presentations/FilePresentation.fxml
+++ b/src/main/resources/ecdar/presentations/FilePresentation.fxml
@@ -18,7 +18,7 @@
             <HBox alignment="CENTER_LEFT" HBox.hgrow="ALWAYS">
                 <StackPane  style="-fx-padding: 0em 1em 0em 1em;">
                     <Circle id="iconBackground" radius="1.25" styleClass="responsive-circle-radius"/>
-                    <StackPane fx:id="filePane" styleClass="responsive-small-image-sizing">
+                    <StackPane fx:id="fileImageStackPane" styleClass="responsive-small-image-sizing">
                         <ImageView fx:id="fileImage"/>
                     </StackPane>
                 </StackPane>


### PR DESCRIPTION
The declaration was placed slightly too high on the canvas the first line of the text area was therefore hidden below the toolbar. The zoom toolbar was intercepting the mouse events, which meant that the top-left corner of the declaration could not be clicked

The current issue:
![before_dec_fix](https://user-images.githubusercontent.com/42961494/181445690-ff46d73e-8c8a-4fc9-93f6-2f603e4a815d.gif)

How it looks after this fix;
![after_dec_fix](https://user-images.githubusercontent.com/42961494/181445715-b164ebe2-11bb-47f1-a781-6f8dcf73d392.gif)
