### PR TITLE
Query whitespace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,9 @@ dependencies {
     implementation group: 'de.codecentric.centerdevice', name: 'javafxsvg', version: '1.3.0'
     implementation group: 'com.github.jiconfont', name: 'jiconfont-javafx', version: '1.0.0'
     implementation group: 'com.github.jiconfont', name: 'jiconfont-google_material_design_icons', version: '2.2.0.2'
-    implementation 'org.kordamp.ikonli:ikonli-core:12.3.1'
-    implementation 'org.kordamp.ikonli:ikonli-material-pack:12.3.1'
-    implementation 'org.kordamp.ikonli:ikonli-javafx:12.3.1'
+    implementation 'org.kordamp.ikonli:ikonli-core:12.2.0'
+    implementation 'org.kordamp.ikonli:ikonli-material-pack:12.2.0'
+    implementation 'org.kordamp.ikonli:ikonli-javafx:12.2.0'
     implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'org.springframework:spring-core:5.3.10' // Used for evaluating expressions
     implementation 'org.springframework:spring-expression:5.3.10' // Used for evaluating expressions

--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,9 @@ dependencies {
     implementation group: 'de.codecentric.centerdevice', name: 'javafxsvg', version: '1.3.0'
     implementation group: 'com.github.jiconfont', name: 'jiconfont-javafx', version: '1.0.0'
     implementation group: 'com.github.jiconfont', name: 'jiconfont-google_material_design_icons', version: '2.2.0.2'
-    implementation 'org.kordamp.ikonli:ikonli-core:12.2.0'
-    implementation 'org.kordamp.ikonli:ikonli-material-pack:12.2.0'
-    implementation 'org.kordamp.ikonli:ikonli-javafx:12.2.0'
+    implementation 'org.kordamp.ikonli:ikonli-core:12.3.1'
+    implementation 'org.kordamp.ikonli:ikonli-material-pack:12.3.1'
+    implementation 'org.kordamp.ikonli:ikonli-javafx:12.3.1'
     implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'org.springframework:spring-core:5.3.10' // Used for evaluating expressions
     implementation 'org.springframework:spring-expression:5.3.10' // Used for evaluating expressions

--- a/src/main/java/ecdar/abstractions/Query.java
+++ b/src/main/java/ecdar/abstractions/Query.java
@@ -133,7 +133,7 @@ public class Query implements Serializable {
                 return;
             }
 
-            Ecdar.getBackendDriver().addQueryToExecutionQueue(getType().getQueryName() + ": " + getQuery().replaceAll("\\s", "") + " " + getIgnoredInputOutputsOnQuery(),
+            Ecdar.getBackendDriver().addQueryToExecutionQueue(getType().getQueryName() + ": \"" + getQuery() + "\" " + getIgnoredInputOutputsOnQuery(),
                     getBackend(),
                     aBoolean -> {
                         if (aBoolean) {

--- a/src/main/java/ecdar/utility/helpers/StringValidator.java
+++ b/src/main/java/ecdar/utility/helpers/StringValidator.java
@@ -3,8 +3,10 @@ package ecdar.utility.helpers;
 public class StringValidator {
     public static boolean validateQuery(String input) {
         int openingParentheses = 0, closingParentheses = 0;
-        
+
         for (char c : input.toCharArray()) {
+            if (c == '\"') return false;
+
             if (c == '(') openingParentheses++;
             else if (c == ')') closingParentheses++;
         }

--- a/src/test/java/ecdar/utility/StringValidatorTest.java
+++ b/src/test/java/ecdar/utility/StringValidatorTest.java
@@ -27,6 +27,13 @@ public class StringValidatorTest {
     }
 
     @Test
+    public void queryWithQuoteMarkReturnsFalse() {
+        final boolean result = StringValidator.validateQuery("(A)\" something");
+
+        Assertions.assertFalse(result);
+    }
+
+    @Test
     public void validComponentNameReturnsTrue() {
         final boolean result = StringValidator.validateComponentName("Administrator");
 


### PR DESCRIPTION
As the new feature 'saveAs' will need the query whitespace to be preserved, this allows that by enclosing the queries in " 's before executing them. The string validator has also been extended to disallow the " character to be present in queries

Closes #85 