### PR TITLE
Exception when trying to save backends with no backends FIXED

### DIFF
--- a/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
+++ b/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
@@ -65,6 +65,11 @@ public class BackendOptionsDialogController implements Initializable {
                 }
             }
 
+            if (backendInstances.size() < 1) {
+                Ecdar.showToast("Please add an engine instance or press: \"" + resetBackendsButton.getText() + "\"");
+                return false;
+            }
+
             // Close all backend connections to avoid dangling backend connections when port range is changed
             try {
                 Ecdar.getBackendDriver().closeAllBackendConnections();


### PR DESCRIPTION
Trying to press _Save_ in the _Backend Options_ dialog when no backends have been added causes an exception. This pull request prevents the dialog from being closed and instead displays a toast. The dialog can still be closed by pressing _Cancel_, which reverts any changes made to the backends

Error:
![empty_backend_exception](https://user-images.githubusercontent.com/42961494/185053167-5b0b51d1-6da1-4680-ba38-17058cc2412c.gif)
