### PR TITLE
Fix error when initializing submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/main/proto"]
 	path = src/main/proto
-	url = git@github.com:Ecdar/Ecdar-ProtoBuf.git
+	url = https://github.com/Ecdar/Ecdar-ProtoBuf.git


### PR DESCRIPTION
Should fix the following error message when trying to initialize submodules while not being logged in with github account. (from Rumle in discord)
```
Cloning into '.../Ecdar-GUI/src/main/proto'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:Ecdar/Ecdar-ProtoBuf.git' into submodule path 'C:/Users/datem/Desktop/Ecdar-GUI/src/main/proto' failed
Failed to clone 'src/main/proto'. Retry scheduled
```
Found the fix here: https://stackoverflow.com/a/34081606/11530695