### PR TITLE
Fix so new connections are only added as backend connections after they are 'ready'

### DIFF
--- a/src/main/java/ecdar/backend/BackendDriver.java
+++ b/src/main/java/ecdar/backend/BackendDriver.java
@@ -150,7 +150,6 @@ public class BackendDriver {
 
         EcdarBackendGrpc.EcdarBackendStub stub = EcdarBackendGrpc.newStub(channel);
         BackendConnection newConnection = new BackendConnection(backend, p, stub, channel);
-        addBackendConnection(newConnection);
 
         QueryProtos.ComponentsUpdateRequest.Builder componentsBuilder = QueryProtos.ComponentsUpdateRequest.newBuilder();
         for (Component c : Ecdar.getProject().getComponents()) {


### PR DESCRIPTION
New connections are added to the backend connections here: https://github.com/Ecdar/Ecdar-GUI/blob/9ca653b7817706f132d88c8a773a0487e99c6038/src/main/java/ecdar/backend/BackendDriver.java#L153

But that is before the `updateComponents` query has completed, so a query can take the backend before it is ready. This results in a bunch of non-deterministic errors when executing queries, one being the `UNAVAILABLE: io exception` error.

The backend should only be added on the `onCompleted` as is already done: https://github.com/Ecdar/Ecdar-GUI/blob/9ca653b7817706f132d88c8a773a0487e99c6038/src/main/java/ecdar/backend/BackendDriver.java#L171

After this small fix you can spam queries to your heart's content with no issues :)