### PR TITLE
Declaration alignment FIX

### DIFF
--- a/src/main/java/ecdar/Ecdar.java
+++ b/src/main/java/ecdar/Ecdar.java
@@ -302,7 +302,6 @@ public class Ecdar extends Application {
 
             try {
                 backendDriver.closeAllBackendConnections();
-                queryHandler.closeAllBackendConnections();
             } catch (IOException e) {
                 e.printStackTrace();
             }
@@ -316,7 +315,6 @@ public class Ecdar extends Application {
             // to prevent dangling connections and queries
             try {
                 backendDriver.closeAllBackendConnections();
-                queryHandler.closeAllBackendConnections();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/ecdar/Ecdar.java
+++ b/src/main/java/ecdar/Ecdar.java
@@ -49,7 +49,7 @@ public class Ecdar extends Application {
     private static EcdarPresentation presentation;
     private static BooleanProperty isUICached = new SimpleBooleanProperty();
     public static BooleanProperty shouldRunBackgroundQueries = new SimpleBooleanProperty(true);
-    private static final BooleanProperty isSplit = new SimpleBooleanProperty(true); //Set to true to ensure correct behaviour at first toggle.
+    private static final BooleanProperty isSplit = new SimpleBooleanProperty(false);
     private static BackendDriver backendDriver = new BackendDriver();
     private static QueryHandler queryHandler = new QueryHandler(backendDriver);
     private Stage debugStage;
@@ -168,15 +168,15 @@ public class Ecdar extends Application {
         return presentation.toggleQueryPane();
     }
 
+    public static BooleanProperty isSplitProperty() {
+        return isSplit;
+    }
+
     /**
      * Toggles whether to canvas is split or single.
-     *
-     * @return the property specifying whether the canvas is split
      */
-    public static BooleanProperty toggleCanvasSplit() {
+    public static void toggleCanvasSplit() {
         isSplit.set(!isSplit.get());
-
-        return isSplit;
     }
 
     /**

--- a/src/main/java/ecdar/backend/BackendDriver.java
+++ b/src/main/java/ecdar/backend/BackendDriver.java
@@ -18,11 +18,13 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 public class BackendDriver {
-    private final BlockingQueue<GrpcRequest> requestQueue = new ArrayBlockingQueue<>(200);
-    private final Map<BackendInstance, BlockingQueue<BackendConnection>> openBackendConnections = new HashMap<>();
     private final int responseDeadline = 20000;
     private final int rerunRequestDelay = 200;
     private final int numberOfRetriesPerQuery = 5;
+
+    private final List<BackendConnection> startedBackendConnections = new ArrayList<>();
+    private final Map<BackendInstance, BlockingQueue<BackendConnection>> availableBackendConnections = new HashMap<>();
+    private final BlockingQueue<GrpcRequest> requestQueue = new ArrayBlockingQueue<>(200);
 
     public BackendDriver() {
         // ToDo NIELS: Consider multiple consumer threads using 'for(int i = 0; i < x; i++) {}'
@@ -44,8 +46,8 @@ public class BackendDriver {
         requestQueue.add(request);
     }
 
-    public void addBackendConnection(BackendConnection backendConnection) {
-        var relatedQueue = this.openBackendConnections.get(backendConnection.getBackendInstance());
+    public void setConnectionAsAvailable(BackendConnection backendConnection) {
+        var relatedQueue = this.availableBackendConnections.get(backendConnection.getBackendInstance());
         if (!relatedQueue.contains(backendConnection)) relatedQueue.add(backendConnection);
     }
 
@@ -55,9 +57,8 @@ public class BackendDriver {
      * @throws IOException if any of the sockets do not respond
      */
     public void closeAllBackendConnections() throws IOException {
-        for (BlockingQueue<BackendConnection> bq : openBackendConnections.values()) {
-            for (BackendConnection bc : bq) bc.close();
-        }
+        availableBackendConnections.clear();
+        for (BackendConnection bc : startedBackendConnections) bc.close();
     }
 
     /**
@@ -73,16 +74,16 @@ public class BackendDriver {
     private BackendConnection getBackendConnection(BackendInstance backend) throws BackendException.NoAvailableBackendConnectionException {
         BackendConnection connection;
         try {
-            if (!openBackendConnections.containsKey(backend))
-                openBackendConnections.put(backend, new ArrayBlockingQueue<>(backend.getNumberOfInstances() + 1));
+            if (!availableBackendConnections.containsKey(backend))
+                availableBackendConnections.put(backend, new ArrayBlockingQueue<>(backend.getNumberOfInstances() + 1));
 
             // If no open connection is free, attempt to start a new one
-            if (openBackendConnections.get(backend).size() < 1) {
+            if (availableBackendConnections.get(backend).size() < 1) {
                 tryStartNewBackendConnection(backend);
             }
 
             // Block until a connection becomes available
-            connection = openBackendConnections.get(backend).take();
+            connection = availableBackendConnections.get(backend).take();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -123,7 +124,7 @@ public class BackendDriver {
             } while (!p.isAlive());
         } else {
             // Filter open connections to this backend and map their used ports to an int stream
-            var activeEnginePorts = openBackendConnections.get(backend).stream()
+            var activeEnginePorts = startedBackendConnections.stream()
                     .mapToInt((bi) -> Integer.parseInt(bi.getStub().getChannel().authority().split(":", 2)[1]));
 
             int currentPort = backend.getPortStart();
@@ -150,6 +151,7 @@ public class BackendDriver {
 
         EcdarBackendGrpc.EcdarBackendStub stub = EcdarBackendGrpc.newStub(channel);
         BackendConnection newConnection = new BackendConnection(backend, p, stub, channel);
+        startedBackendConnections.add(newConnection);
 
         QueryProtos.ComponentsUpdateRequest.Builder componentsBuilder = QueryProtos.ComponentsUpdateRequest.newBuilder();
         for (Component c : Ecdar.getProject().getComponents()) {
@@ -167,7 +169,7 @@ public class BackendDriver {
 
             @Override
             public void onCompleted() {
-                addBackendConnection(newConnection);
+                setConnectionAsAvailable(newConnection);
             }
         };
 

--- a/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
+++ b/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
@@ -73,7 +73,6 @@ public class BackendOptionsDialogController implements Initializable {
             // Close all backend connections to avoid dangling backend connections when port range is changed
             try {
                 Ecdar.getBackendDriver().closeAllBackendConnections();
-                Ecdar.getQueryExecutor().closeAllBackendConnections();
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/ecdar/controllers/CanvasController.java
+++ b/src/main/java/ecdar/controllers/CanvasController.java
@@ -145,7 +145,7 @@ public class CanvasController implements Initializable {
             modelPane.getChildren().add(activeComponentPresentation);
 
             // To avoid NullPointerException on initial model
-            if (oldObject != null) zoomHelper.resetZoom();
+            Platform.runLater(zoomHelper::resetZoom);
 
         } else if (newObject instanceof DeclarationsPresentation) {
             activeComponentPresentation = null;

--- a/src/main/java/ecdar/controllers/CanvasController.java
+++ b/src/main/java/ecdar/controllers/CanvasController.java
@@ -152,10 +152,11 @@ public class CanvasController implements Initializable {
             modelPane.getChildren().add(newObject);
 
             // Bind size of Declaration to size of the model pane to ensure alignment and avoid drag
-            ((DeclarationsController) newObject.getController()).root.minWidthProperty().bind(modelPane.minWidthProperty());
-            ((DeclarationsController) newObject.getController()).root.maxWidthProperty().bind(modelPane.maxWidthProperty());
-            ((DeclarationsController) newObject.getController()).root.minHeightProperty().bind(modelPane.minHeightProperty());
-            ((DeclarationsController) newObject.getController()).root.maxHeightProperty().bind(modelPane.maxHeightProperty());
+            DeclarationsController declarationsController = (DeclarationsController) newObject.getController();
+            declarationsController.root.minWidthProperty().bind(modelPane.minWidthProperty());
+            declarationsController.root.maxWidthProperty().bind(modelPane.maxWidthProperty());
+            declarationsController.root.minHeightProperty().bind(modelPane.minHeightProperty());
+            declarationsController.root.maxHeightProperty().bind(modelPane.maxHeightProperty());
         } else if (newObject instanceof SystemPresentation) {
             activeComponentPresentation = null;
             modelPane.getChildren().add(newObject);

--- a/src/main/java/ecdar/controllers/CanvasController.java
+++ b/src/main/java/ecdar/controllers/CanvasController.java
@@ -150,6 +150,12 @@ public class CanvasController implements Initializable {
         } else if (newObject instanceof DeclarationsPresentation) {
             activeComponentPresentation = null;
             modelPane.getChildren().add(newObject);
+
+            // Bind size of Declaration to size of the model pane to ensure alignment and avoid drag
+            ((DeclarationsController) newObject.getController()).root.minWidthProperty().bind(modelPane.minWidthProperty());
+            ((DeclarationsController) newObject.getController()).root.maxWidthProperty().bind(modelPane.maxWidthProperty());
+            ((DeclarationsController) newObject.getController()).root.minHeightProperty().bind(modelPane.minHeightProperty());
+            ((DeclarationsController) newObject.getController()).root.maxHeightProperty().bind(modelPane.maxHeightProperty());
         } else if (newObject instanceof SystemPresentation) {
             activeComponentPresentation = null;
             modelPane.getChildren().add(newObject);

--- a/src/main/java/ecdar/controllers/DeclarationsController.java
+++ b/src/main/java/ecdar/controllers/DeclarationsController.java
@@ -1,6 +1,5 @@
 package ecdar.controllers;
 
-import ecdar.Ecdar;
 import ecdar.abstractions.Declarations;
 import ecdar.abstractions.HighLevelModel;
 import ecdar.utility.helpers.UPPAALSyntaxHighlighter;
@@ -19,9 +18,9 @@ import java.util.ResourceBundle;
  * Controller for overall declarations.
  */
 public class DeclarationsController extends HighLevelModelController implements Initializable {
-    public StyleClassedTextArea textArea;
     public StackPane root;
     public BorderPane frame;
+    public StyleClassedTextArea textArea;
 
     private final ObjectProperty<Declarations> declarations;
 
@@ -35,20 +34,7 @@ public class DeclarationsController extends HighLevelModelController implements 
 
     @Override
     public void initialize(final URL location, final ResourceBundle resources) {
-        initializeWidthAndHeight();
         initializeText();
-    }
-
-    /**
-     * Initializes width and height of the text editor field, such that it fills up the whole canvas
-     */
-    private void initializeWidthAndHeight() {
-        // Fetch width and height of canvas and update
-        root.minWidthProperty().bind(Ecdar.getPresentation().getController().canvasPane.minWidthProperty());
-        root.maxWidthProperty().bind(Ecdar.getPresentation().getController().canvasPane.maxWidthProperty());
-        root.minHeightProperty().bind(Ecdar.getPresentation().getController().canvasPane.minHeightProperty());
-        root.maxHeightProperty().bind(Ecdar.getPresentation().getController().canvasPane.maxHeightProperty());
-        textArea.setTranslateY(20);
     }
 
     /**

--- a/src/main/java/ecdar/controllers/EcdarController.java
+++ b/src/main/java/ecdar/controllers/EcdarController.java
@@ -654,13 +654,15 @@ public class EcdarController implements Initializable {
 
         menuBarViewCanvasSplit.getGraphic().setOpacity(1);
         menuBarViewCanvasSplit.setOnAction(event -> {
-            final BooleanProperty isSplit = Ecdar.toggleCanvasSplit();
-            if (isSplit.get()) {
-                Platform.runLater(this::setCanvasModeToSingular);
-                menuBarViewCanvasSplit.setText("Split canvas");
-            } else {
+            Ecdar.toggleCanvasSplit();
+        });
+        Ecdar.isSplitProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue) {
                 Platform.runLater(this::setCanvasModeToSplit);
                 menuBarViewCanvasSplit.setText("Merge canvases");
+            } else {
+                Platform.runLater(this::setCanvasModeToSingular);
+                menuBarViewCanvasSplit.setText("Split canvas");
             }
         });
 
@@ -723,7 +725,7 @@ public class EcdarController implements Initializable {
                 try {
                     Ecdar.projectDirectory.set(file.getAbsolutePath());
                     Ecdar.initializeProjectFolder();
-                    setCanvasModeToSingular();
+                    Ecdar.isSplitProperty().set(false);
                     UndoRedoStack.clear();
                     addProjectToRecentProjects(file.getAbsolutePath());
                 } catch (final IOException e) {
@@ -745,7 +747,7 @@ public class EcdarController implements Initializable {
                 try {
                     Ecdar.projectDirectory.set(path);
                     Ecdar.initializeProjectFolder();
-                    setCanvasModeToSingular();
+                    Ecdar.isSplitProperty().set(false);
                 } catch (IOException ex) {
                     Ecdar.showToast("Unable to load project: \"" + path + "\"");
                 }
@@ -903,6 +905,8 @@ public class EcdarController implements Initializable {
 
         Ecdar.projectDirectory.set(null);
 
+        Ecdar.isSplitProperty().set(false);
+
         projectPane.getController().resetProject();
 
         UndoRedoStack.clear();
@@ -1058,6 +1062,7 @@ public class EcdarController implements Initializable {
 
     /**
      * Get list of shown HighLevelModelPresentations
+     *
      * @return a list of all the HighLevelModelPresentations currently being shown
      */
     private List<HighLevelModelPresentation> getActiveModelPresentations() {

--- a/src/main/java/ecdar/controllers/EcdarController.java
+++ b/src/main/java/ecdar/controllers/EcdarController.java
@@ -525,7 +525,7 @@ public class EcdarController implements Initializable {
     }
 
     public void setActiveModelPresentationForActiveCanvas(HighLevelModelPresentation newActiveModelPresentation) {
-        projectPane.getController().changeOneActiveModelPresentationForAnother(EcdarController.getActiveCanvasPresentation().getController().getActiveModelPresentation(), newActiveModelPresentation);
+        projectPane.getController().swapHighlightBetweenTwoModelFiles(EcdarController.getActiveCanvasPresentation().getController().getActiveModelPresentation(), newActiveModelPresentation);
         EcdarController.getActiveCanvasPresentation().getController().setActiveModelPresentation(newActiveModelPresentation);
     }
 
@@ -974,7 +974,7 @@ public class EcdarController implements Initializable {
         canvasPresentation.getController().zoomablePane.minHeightProperty().bind(canvasPane.heightProperty());
         canvasPresentation.getController().zoomablePane.maxHeightProperty().bind(canvasPane.heightProperty());
 
-        projectPane.getController().setActiveModelPresentations(canvasPresentation.getController().getActiveModelPresentation());
+        projectPane.getController().setHighlightedForModelFiles(getActiveModelPresentations());
     }
 
     /**
@@ -1039,13 +1039,29 @@ public class EcdarController implements Initializable {
         canvasGrid.add(canvasPresentation, 1, 1);
 
         canvasPane.getChildren().add(canvasGrid);
-        projectPane.getController().setActiveModelPresentations(getActiveModelPresentations(canvasGrid));
+        projectPane.getController().setHighlightedForModelFiles(getActiveModelPresentations());
     }
 
-    private static List<HighLevelModelPresentation> getActiveModelPresentations(GridPane canvasGrid) {
-        return canvasGrid.getChildren()
-                .stream().map(canvas -> ((CanvasPresentation) canvas)
-                        .getController().getActiveModelPresentation()).collect(Collectors.toList());
+    /**
+     * Get list of shown HighLevelModelPresentations
+     * @return a list of all the HighLevelModelPresentations currently being shown
+     */
+    private List<HighLevelModelPresentation> getActiveModelPresentations() {
+        Pane canvasChild = (Pane) canvasPane.getChildren().get(0);
+
+        if (canvasChild instanceof GridPane) {
+            return canvasChild.getChildren()
+                    .stream().map(canvas -> ((CanvasPresentation) canvas)
+                            .getController().getActiveModelPresentation()).filter(Objects::nonNull).collect(Collectors.toList());
+        } else if (canvasChild instanceof CanvasPresentation) {
+            return new ArrayList<>() {
+                {
+                    ((CanvasPresentation) canvasChild).getController().getActiveModelPresentation();
+                }
+            };
+        }
+
+        return new ArrayList<>();
     }
 
     /**

--- a/src/main/java/ecdar/controllers/EcdarController.java
+++ b/src/main/java/ecdar/controllers/EcdarController.java
@@ -723,6 +723,7 @@ public class EcdarController implements Initializable {
                 try {
                     Ecdar.projectDirectory.set(file.getAbsolutePath());
                     Ecdar.initializeProjectFolder();
+                    setCanvasModeToSingular();
                     UndoRedoStack.clear();
                     addProjectToRecentProjects(file.getAbsolutePath());
                 } catch (final IOException e) {
@@ -744,6 +745,7 @@ public class EcdarController implements Initializable {
                 try {
                     Ecdar.projectDirectory.set(path);
                     Ecdar.initializeProjectFolder();
+                    setCanvasModeToSingular();
                 } catch (IOException ex) {
                     Ecdar.showToast("Unable to load project: \"" + path + "\"");
                 }

--- a/src/main/java/ecdar/controllers/EcdarController.java
+++ b/src/main/java/ecdar/controllers/EcdarController.java
@@ -14,6 +14,7 @@ import ecdar.utility.UndoRedoStack;
 import ecdar.utility.colors.Color;
 import ecdar.utility.colors.EnabledColor;
 import ecdar.utility.helpers.SelectHelper;
+import ecdar.utility.helpers.ZoomHelper;
 import ecdar.utility.keyboard.Keybind;
 import ecdar.utility.keyboard.KeyboardTracker;
 import ecdar.utility.keyboard.NudgeDirection;
@@ -522,6 +523,17 @@ public class EcdarController implements Initializable {
         activeCanvasPresentation.get().setOpacity(0.75);
         newActiveCanvasPresentation.setOpacity(1);
         activeCanvasPresentation.set(newActiveCanvasPresentation);
+        updateZoomShortcutBindings(newActiveCanvasPresentation.getController().zoomHelper);
+    }
+
+    /**
+     * Binds the zoom shortcuts to the provided zoom helper (consequently unbinds the previously bound zoom helper)
+     */
+    private static void updateZoomShortcutBindings(ZoomHelper zoomHelper) {
+        KeyboardTracker.registerKeybind(KeyboardTracker.ZOOM_IN, new Keybind(new KeyCodeCombination(KeyCode.PLUS, KeyCombination.SHORTCUT_DOWN), zoomHelper::zoomIn));
+        KeyboardTracker.registerKeybind(KeyboardTracker.ZOOM_OUT, new Keybind(new KeyCodeCombination(KeyCode.MINUS, KeyCombination.SHORTCUT_DOWN), zoomHelper::zoomOut));
+        KeyboardTracker.registerKeybind(KeyboardTracker.ZOOM_TO_FIT, new Keybind(new KeyCodeCombination(KeyCode.EQUALS, KeyCombination.SHORTCUT_DOWN), zoomHelper::zoomToFit));
+        KeyboardTracker.registerKeybind(KeyboardTracker.RESET_ZOOM, new Keybind(new KeyCodeCombination(KeyCode.DIGIT0, KeyCombination.SHORTCUT_DOWN), zoomHelper::resetZoom));
     }
 
     public void setActiveModelPresentationForActiveCanvas(HighLevelModelPresentation newActiveModelPresentation) {

--- a/src/main/java/ecdar/controllers/ProjectPaneController.java
+++ b/src/main/java/ecdar/controllers/ProjectPaneController.java
@@ -451,6 +451,27 @@ public class ProjectPaneController implements Initializable {
         return names;
     }
 
+    public ObservableList<ComponentPresentation> getComponentPresentations() {
+        return componentPresentations;
+    }
+
+    public void setHighlightedForModelFiles(List<HighLevelModelPresentation> currentlyActiveModelPresentations) {
+        Platform.runLater(() -> {
+            modelPresentationMap.values().forEach(fp -> fp.getController().setIsActive(false));
+
+            for (HighLevelModelPresentation modelPresentation : currentlyActiveModelPresentations) {
+                modelPresentationMap.get(modelPresentation).getController().setIsActive(true);
+            }
+        });
+    }
+
+    public void swapHighlightBetweenTwoModelFiles(final HighLevelModelPresentation oldActive, final HighLevelModelPresentation newActive) {
+        if (modelPresentationMap.get(oldActive) != null) modelPresentationMap.get(oldActive)
+                .getController()
+                .setIsActive(false);
+        modelPresentationMap.get(newActive).getController().setIsActive(true);
+    }
+
     /**
      * Method for creating a new component
      */
@@ -493,33 +514,5 @@ public class ProjectPaneController implements Initializable {
             this.tempFilesList.setVisible(false);
             this.tempFilesList.setManaged(false);
         }
-    }
-
-    public ObservableList<ComponentPresentation> getComponentPresentations() {
-        return componentPresentations;
-    }
-
-    public void setActiveModelPresentations(HighLevelModelPresentation activeModelPresentation) {
-        Platform.runLater(() -> {
-            modelPresentationMap.values().forEach(fp -> fp.getController().setIsActive(false));
-            modelPresentationMap.get(activeModelPresentation).getController().setIsActive(true);
-        });
-    }
-
-    public void setActiveModelPresentations(List<HighLevelModelPresentation> currentlyActiveModelPresentations) {
-        Platform.runLater(() -> {
-            modelPresentationMap.values().forEach(fp -> fp.getController().setIsActive(false));
-
-            for (HighLevelModelPresentation modelPresentation : currentlyActiveModelPresentations) {
-                modelPresentationMap.get(modelPresentation).getController().setIsActive(true);
-            }
-        });
-    }
-
-    public void changeOneActiveModelPresentationForAnother(final HighLevelModelPresentation oldActive, final HighLevelModelPresentation newActive) {
-        if (modelPresentationMap.get(oldActive) != null) modelPresentationMap.get(oldActive)
-                .getController()
-                .setIsActive(false);
-        modelPresentationMap.get(newActive).getController().setIsActive(true);
     }
 }

--- a/src/main/java/ecdar/controllers/ProjectPaneController.java
+++ b/src/main/java/ecdar/controllers/ProjectPaneController.java
@@ -459,7 +459,7 @@ public class ProjectPaneController implements Initializable {
         modelPresentationMap.values().forEach(fp -> fp.getController().setIsActive(false));
 
         for (HighLevelModelPresentation modelPresentation : currentlyActiveModelPresentations) {
-            modelPresentationMap.get(modelPresentation).getController().setIsActive(true);
+            if (modelPresentationMap.containsKey(modelPresentation)) modelPresentationMap.get(modelPresentation).getController().setIsActive(true);
         }
     }
 

--- a/src/main/java/ecdar/controllers/ProjectPaneController.java
+++ b/src/main/java/ecdar/controllers/ProjectPaneController.java
@@ -456,21 +456,19 @@ public class ProjectPaneController implements Initializable {
     }
 
     public void setHighlightedForModelFiles(List<HighLevelModelPresentation> currentlyActiveModelPresentations) {
-        Platform.runLater(() -> {
-            modelPresentationMap.values().forEach(fp -> fp.getController().setIsActive(false));
+        modelPresentationMap.values().forEach(fp -> fp.getController().setIsActive(false));
 
-            for (HighLevelModelPresentation modelPresentation : currentlyActiveModelPresentations) {
-                modelPresentationMap.get(modelPresentation).getController().setIsActive(true);
-            }
-        });
+        for (HighLevelModelPresentation modelPresentation : currentlyActiveModelPresentations) {
+            modelPresentationMap.get(modelPresentation).getController().setIsActive(true);
+        }
     }
 
     public void swapHighlightBetweenTwoModelFiles(final HighLevelModelPresentation oldActive, final HighLevelModelPresentation newActive) {
-        if (newActive == null) return; // newActive is null when opening an existing project
-        if (modelPresentationMap.get(oldActive) != null) modelPresentationMap.get(oldActive)
+        if (modelPresentationMap.containsKey(oldActive)) modelPresentationMap.get(oldActive)
                 .getController()
                 .setIsActive(false);
-        modelPresentationMap.get(newActive).getController().setIsActive(true);
+
+        if (modelPresentationMap.containsKey(newActive)) modelPresentationMap.get(newActive).getController().setIsActive(true); // newActive is not in the map when opening an existing project
     }
 
     /**

--- a/src/main/java/ecdar/controllers/ProjectPaneController.java
+++ b/src/main/java/ecdar/controllers/ProjectPaneController.java
@@ -466,6 +466,7 @@ public class ProjectPaneController implements Initializable {
     }
 
     public void swapHighlightBetweenTwoModelFiles(final HighLevelModelPresentation oldActive, final HighLevelModelPresentation newActive) {
+        if (newActive == null) return; // newActive is null when opening an existing project
         if (modelPresentationMap.get(oldActive) != null) modelPresentationMap.get(oldActive)
                 .getController()
                 .setIsActive(false);

--- a/src/main/java/ecdar/presentations/EcdarPresentation.java
+++ b/src/main/java/ecdar/presentations/EcdarPresentation.java
@@ -111,10 +111,6 @@ public class EcdarPresentation extends StackPane {
         });
 
         initializeHelpImages();
-        KeyboardTracker.registerKeybind(KeyboardTracker.ZOOM_IN, new Keybind(new KeyCodeCombination(KeyCode.PLUS, KeyCombination.SHORTCUT_DOWN), () -> EcdarController.getActiveCanvasPresentation().getController().zoomHelper.zoomIn()));
-        KeyboardTracker.registerKeybind(KeyboardTracker.ZOOM_OUT, new Keybind(new KeyCodeCombination(KeyCode.MINUS, KeyCombination.SHORTCUT_DOWN), () -> EcdarController.getActiveCanvasPresentation().getController().zoomHelper.zoomOut()));
-        KeyboardTracker.registerKeybind(KeyboardTracker.ZOOM_TO_FIT, new Keybind(new KeyCodeCombination(KeyCode.EQUALS, KeyCombination.SHORTCUT_DOWN), () -> EcdarController.getActiveCanvasPresentation().getController().zoomHelper.zoomToFit()));
-        KeyboardTracker.registerKeybind(KeyboardTracker.RESET_ZOOM, new Keybind(new KeyCodeCombination(KeyCode.DIGIT0, KeyCombination.SHORTCUT_DOWN), () -> EcdarController.getActiveCanvasPresentation().getController().zoomHelper.resetZoom()));
         KeyboardTracker.registerKeybind(KeyboardTracker.UNDO, new Keybind(new KeyCodeCombination(KeyCode.Z, KeyCombination.SHORTCUT_DOWN), UndoRedoStack::undo));
         KeyboardTracker.registerKeybind(KeyboardTracker.REDO, new Keybind(new KeyCodeCombination(KeyCode.Z, KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN), UndoRedoStack::redo));
 

--- a/src/main/java/ecdar/utility/helpers/ZoomHelper.java
+++ b/src/main/java/ecdar/utility/helpers/ZoomHelper.java
@@ -96,16 +96,22 @@ public class ZoomHelper {
     public void zoomToFit() {
         if (!active || model == null) return;
 
-        double neededWidth = (model instanceof ComponentPresentation ?
-                (model.getMinWidth()
-                        + ((ComponentController) model.getController()).inputSignatureContainer.getWidth()
-                        + ((ComponentController) model.getController()).outputSignatureContainer.getWidth())
-                : model.getMinWidth());
-
+        double neededWidth = getWidthNeededForModel();
         double newScale = Math.min(canvasPresentation.getWidth() / neededWidth, canvasPresentation.getHeight() / model.getMinHeight() - 0.2); // 0.2 subtracted for margin
 
         currentZoomFactor.set(newScale);
         centerComponentOrSystem();
+    }
+
+    private double getWidthNeededForModel() {
+        if (model instanceof ComponentPresentation) {
+            ComponentController componentController = (ComponentController) model.getController();
+            return model.getMinWidth()
+                    + componentController.inputSignatureContainer.getWidth()
+                    + componentController.outputSignatureContainer.getWidth();
+        }
+
+        return model.getMinWidth();
     }
 
     /**

--- a/src/main/java/ecdar/utility/helpers/ZoomHelper.java
+++ b/src/main/java/ecdar/utility/helpers/ZoomHelper.java
@@ -3,14 +3,9 @@ package ecdar.utility.helpers;
 import ecdar.Ecdar;
 import ecdar.controllers.ComponentController;
 import ecdar.presentations.*;
-import ecdar.utility.keyboard.Keybind;
-import ecdar.utility.keyboard.KeyboardTracker;
 import javafx.application.Platform;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
-import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyCodeCombination;
-import javafx.scene.input.KeyCombination;
 
 public class ZoomHelper {
     public DoubleProperty currentZoomFactor = new SimpleDoubleProperty(1);
@@ -20,13 +15,6 @@ public class ZoomHelper {
     private CanvasPresentation canvasPresentation;
     private HighLevelModelPresentation model;
     private boolean active = true;
-
-    public ZoomHelper() {
-        KeyboardTracker.registerKeybind(KeyboardTracker.ZOOM_IN, new Keybind(new KeyCodeCombination(KeyCode.PLUS, KeyCombination.SHORTCUT_DOWN), this::zoomIn));
-        KeyboardTracker.registerKeybind(KeyboardTracker.ZOOM_OUT, new Keybind(new KeyCodeCombination(KeyCode.MINUS, KeyCombination.SHORTCUT_DOWN), this::zoomOut));
-        KeyboardTracker.registerKeybind(KeyboardTracker.ZOOM_TO_FIT, new Keybind(new KeyCodeCombination(KeyCode.EQUALS, KeyCombination.SHORTCUT_DOWN), this::zoomToFit));
-        KeyboardTracker.registerKeybind(KeyboardTracker.RESET_ZOOM, new Keybind(new KeyCodeCombination(KeyCode.DIGIT0, KeyCombination.SHORTCUT_DOWN), this::resetZoom));
-    }
 
     /**
      * Set the CanvasPresentation and add listeners for both the width and height of the new CanvasPresentation


### PR DESCRIPTION
Alignment and sizing of declarations fixed for split canvas as seen below.

![image](https://user-images.githubusercontent.com/42961494/221131906-73a335f5-b9ed-4c60-83fe-5e42b87a596f.png)

Minor refactoring has been done on the related code, including moving keybinding logic related to zoom to the class that handles the zooming to remove dependencies.