### PR TITLE
Removed the contains deadlock option from the context menu in ComponentController

### DIFF
--- a/src/main/java/ecdar/controllers/ComponentController.java
+++ b/src/main/java/ecdar/controllers/ComponentController.java
@@ -372,23 +372,6 @@ public class ComponentController extends ModelController implements Initializabl
             });
 
             contextMenu.addSpacerElement();
-
-            contextMenu.addClickableListElement("Contains deadlock?", event -> {
-                // Generate the query
-                final String deadlockQuery = BackendHelper.getExistDeadlockQuery(getComponent());
-
-                // Add proper comment
-                final String deadlockComment = "Does " + component.getName() + " contain a deadlock?";
-
-                // Add new query for this component
-                final Query query = new Query(deadlockQuery, deadlockComment, QueryState.UNKNOWN);
-                query.setType(QueryType.REACHABILITY);
-                Ecdar.getProject().getQueries().add(query);
-                Ecdar.getQueryExecutor().executeQuery(query);
-                contextMenu.hide();
-            });
-
-            contextMenu.addSpacerElement();
             contextMenu.addColorPicker(component, component::dye);
         };
 


### PR DESCRIPTION
This PR fixes #104 

## Changes
- Deleted the context menu option for `Contains Deadlock` in `ComponentController.java`

### OBS
I realized that there were a couple of other files still referencing `deadlocks` around the code, due to the somewhat lacking description of this issue I was not sure if I am supposed to handle that as well, please let me know if that is the case.

The locations of other references to the keyword `deadlock` are:
- [`KeyboardTracker.java` on `line 30`](https://github.com/sipman/Ecdar-GUI/blob/283a988e373f588ea83c0dc7789861894df2cc4a/src/main/java/ecdar/utility/keyboard/KeyboardTracker.java#L30)
- [`BackendHelper.java` on `Line 77-93`](https://github.com/sipman/Ecdar-GUI/blob/283a988e373f588ea83c0dc7789861894df2cc4a/src/main/java/ecdar/backend/BackendHelper.java#L77)