### PR TITLE
Dangling engines FIX

### DIFF
--- a/src/main/java/ecdar/Ecdar.java
+++ b/src/main/java/ecdar/Ecdar.java
@@ -302,7 +302,6 @@ public class Ecdar extends Application {
 
             try {
                 backendDriver.closeAllBackendConnections();
-                queryHandler.closeAllBackendConnections();
             } catch (IOException e) {
                 e.printStackTrace();
             }
@@ -316,7 +315,6 @@ public class Ecdar extends Application {
             // to prevent dangling connections and queries
             try {
                 backendDriver.closeAllBackendConnections();
-                queryHandler.closeAllBackendConnections();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/ecdar/backend/BackendDriver.java
+++ b/src/main/java/ecdar/backend/BackendDriver.java
@@ -46,7 +46,7 @@ public class BackendDriver {
         requestQueue.add(request);
     }
 
-    public void addBackendConnection(BackendConnection backendConnection) {
+    public void setConnectionAsAvailable(BackendConnection backendConnection) {
         var relatedQueue = this.availableBackendConnections.get(backendConnection.getBackendInstance());
         if (!relatedQueue.contains(backendConnection)) relatedQueue.add(backendConnection);
     }
@@ -169,7 +169,7 @@ public class BackendDriver {
             @Override
             public void onCompleted() {
                 startedBackendConnections.add(newConnection);
-                addBackendConnection(newConnection);
+                setConnectionAsAvailable(newConnection);
             }
         };
 

--- a/src/main/java/ecdar/backend/BackendDriver.java
+++ b/src/main/java/ecdar/backend/BackendDriver.java
@@ -124,7 +124,7 @@ public class BackendDriver {
             } while (!p.isAlive());
         } else {
             // Filter open connections to this backend and map their used ports to an int stream
-            var activeEnginePorts = availableBackendConnections.get(backend).stream()
+            var activeEnginePorts = startedBackendConnections.stream()
                     .mapToInt((bi) -> Integer.parseInt(bi.getStub().getChannel().authority().split(":", 2)[1]));
 
             int currentPort = backend.getPortStart();
@@ -151,6 +151,7 @@ public class BackendDriver {
 
         EcdarBackendGrpc.EcdarBackendStub stub = EcdarBackendGrpc.newStub(channel);
         BackendConnection newConnection = new BackendConnection(backend, p, stub, channel);
+        startedBackendConnections.add(newConnection);
 
         QueryProtos.ComponentsUpdateRequest.Builder componentsBuilder = QueryProtos.ComponentsUpdateRequest.newBuilder();
         for (Component c : Ecdar.getProject().getComponents()) {
@@ -168,7 +169,6 @@ public class BackendDriver {
 
             @Override
             public void onCompleted() {
-                startedBackendConnections.add(newConnection);
                 setConnectionAsAvailable(newConnection);
             }
         };

--- a/src/main/java/ecdar/backend/QueryHandler.java
+++ b/src/main/java/ecdar/backend/QueryHandler.java
@@ -13,7 +13,6 @@ import io.grpc.stub.StreamObserver;
 import javafx.application.Platform;
 import javafx.collections.ObservableList;
 
-import java.util.ArrayList;
 import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 
@@ -50,13 +49,13 @@ public class QueryHandler {
                 @Override
                 public void onError(Throwable t) {
                     handleQueryBackendError(t, query);
-                    backendDriver.addBackendConnection(backendConnection);
+                    backendDriver.setConnectionAsAvailable(backendConnection);
                 }
 
                 @Override
                 public void onCompleted() {
                     // Release backend connection
-                    backendDriver.addBackendConnection(backendConnection);
+                    backendDriver.setConnectionAsAvailable(backendConnection);
                 }
             };
 

--- a/src/main/java/ecdar/backend/QueryHandler.java
+++ b/src/main/java/ecdar/backend/QueryHandler.java
@@ -19,7 +19,6 @@ import java.util.concurrent.TimeUnit;
 
 public class QueryHandler {
     private final BackendDriver backendDriver;
-    private final ArrayList<BackendConnection> connections = new ArrayList<>();
 
     public QueryHandler(BackendDriver backendDriver) {
         this.backendDriver = backendDriver;
@@ -42,7 +41,6 @@ public class QueryHandler {
         query.errors().set("");
 
         GrpcRequest request = new GrpcRequest(backendConnection -> {
-            connections.add(backendConnection); // Save reference for closing connection on exit
             StreamObserver<QueryProtos.QueryResponse> responseObserver = new StreamObserver<>() {
                 @Override
                 public void onNext(QueryProtos.QueryResponse value) {
@@ -53,14 +51,12 @@ public class QueryHandler {
                 public void onError(Throwable t) {
                     handleQueryBackendError(t, query);
                     backendDriver.addBackendConnection(backendConnection);
-                    connections.remove(backendConnection);
                 }
 
                 @Override
                 public void onCompleted() {
                     // Release backend connection
                     backendDriver.addBackendConnection(backendConnection);
-                    connections.remove(backendConnection);
                 }
             };
 
@@ -73,15 +69,6 @@ public class QueryHandler {
         }, query.getBackend());
 
         backendDriver.addRequestToExecutionQueue(request);
-    }
-
-    /**
-     * Close all open backend connection and kill all locally running processes
-     */
-    public void closeAllBackendConnections() {
-        for (BackendConnection con : connections) {
-            con.close();
-        }
     }
 
     private void handleQueryResponse(QueryProtos.QueryResponse value, Query query) {

--- a/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
+++ b/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
@@ -73,7 +73,6 @@ public class BackendOptionsDialogController implements Initializable {
             // Close all backend connections to avoid dangling backend connections when port range is changed
             try {
                 Ecdar.getBackendDriver().closeAllBackendConnections();
-                Ecdar.getQueryExecutor().closeAllBackendConnections();
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
This PR fixes the issue of having dangling engine processes after exiting the GUI.
This is done by keeping track of started connections in a separate list and still using a `BlockingQueue` for requesting connections. This removes the need for the `QueryHandler` to keep track of the currently used connections

Closes #111 and 
Closes #134 